### PR TITLE
feat: start adding support for aarch64/arm NEON

### DIFF
--- a/benches/dot_product_benchmark.rs
+++ b/benches/dot_product_benchmark.rs
@@ -1,8 +1,9 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::Rng;
-use std::arch::x86_64::*;
 
+#[cfg(target_arch = "x86_64")]
 pub fn dot_product_u8_avx2_fma(a: &[u8], b: &[u8]) -> u64 {
+    use std::arch::x86_64::*;
     assert_eq!(a.len(), b.len());
 
     let mut dot_product: u64 = 0;
@@ -120,6 +121,8 @@ fn bench_dot_product(c: &mut Criterion) {
                 black_box(result)
             })
         });
+
+        #[cfg(target_arch = "x86_64")]
         c.bench_function(&format!("dot_product_u8_avx2_fma_{}", size), |b| {
             b.iter(|| {
                 // Randomly select two vectors for each iteration

--- a/src/models/common.rs
+++ b/src/models/common.rs
@@ -7,7 +7,6 @@ use async_std::stream::Cloned;
 use dashmap::DashMap;
 use futures::future::{join_all, BoxFuture, FutureExt};
 use sha2::{Digest, Sha256};
-use std::arch::x86_64::*;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
 use std::fmt;
@@ -16,6 +15,10 @@ use std::sync::Arc;
 use thiserror::Error;
 use tokio::task;
 
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::*;
+
+#[cfg(target_arch = "x86_64")]
 pub fn dot_product_u8_avx2_fma(a: &[u8], b: &[u8]) -> u64 {
     assert_eq!(a.len(), b.len());
 

--- a/src/models/dot_product.rs
+++ b/src/models/dot_product.rs
@@ -1,99 +1,14 @@
-use rand::Rng;
-use std::arch::x86_64::*;
+#[cfg(target_arch = "aarch64")]
+mod arm64;
 
-fn print_mm256i(name: &str, value: __m256i) {
-    let mut array = [0u8; 32];
-    unsafe {
-        _mm256_storeu_si256(array.as_mut_ptr() as *mut __m256i, value);
-    }
-    print!("{} = [", name);
-    for (i, &byte) in array.iter().enumerate() {
-        if i > 0 {
-            print!(", ");
-        }
-        print!("{:3}", byte);
-    }
-    println!("]");
-}
-#[target_feature(enable = "avx2")]
-pub unsafe fn dot_product_u8_avx2(a: &[u8], b: &[u8]) -> u64 {
-    assert_eq!(a.len(), b.len());
+#[cfg(target_arch = "aarch64")]
+use arm64::*;
 
-    let mut dot_product: u64 = 0;
-    let len = a.len();
-    let chunk_size = 32;
+#[cfg(target_arch = "x86_64")]
+mod x86_64;
 
-    let mut sumlo = _mm256_setzero_si256();
-    let mut sumhi = _mm256_setzero_si256();
-    // Process 32 elements at a time
-    let mut i = 0;
-    while i + chunk_size <= len {
-        // Load 32 elements from each array into AVX2 registers
-        let va = _mm256_loadu_si256(a.as_ptr().add(i) as *const __m256i);
-        let vb = _mm256_loadu_si256(b.as_ptr().add(i) as *const __m256i);
-
-        // Unpack 8-bit integers to 16-bit integers
-        let va_lo = _mm256_unpacklo_epi8(va, _mm256_setzero_si256());
-        let va_hi = _mm256_unpackhi_epi8(va, _mm256_setzero_si256());
-        let vb_lo = _mm256_unpacklo_epi8(vb, _mm256_setzero_si256());
-        let vb_hi = _mm256_unpackhi_epi8(vb, _mm256_setzero_si256());
-
-        // print_mm256i("va_lo", va_lo);
-
-        // Multiply and add packed 16-bit integers
-        let prod_lo = _mm256_madd_epi16(va_lo, vb_lo);
-        let prod_hi = _mm256_madd_epi16(va_hi, vb_hi);
-        // print_mm256i("prod_lo", prod_lo);
-
-        sumlo = _mm256_add_epi32(sumlo, prod_lo);
-        sumhi = _mm256_add_epi32(sumhi, prod_hi);
-
-        i += chunk_size;
-    }
-
-    dot_product += accumulate_u32(sumlo) as u64;
-    dot_product += accumulate_u32(sumhi) as u64;
-
-    // Handle remaining elements
-    while i < len {
-        dot_product += a[i] as u64 * b[i] as u64;
-        i += 1;
-    }
-    dot_product
-}
-
-#[target_feature(enable = "avx2")]
-unsafe fn accumulate_u32(x: __m256i) -> u32 {
-    // Horizontal add within 256-bit lanes
-    let sum1 = _mm256_hadd_epi32(x, x);
-    // Horizontal add again
-    let sum2 = _mm256_hadd_epi32(sum1, sum1);
-    // Extract lower 128 bits
-    let sum_low = _mm256_castsi256_si128(sum2);
-    // Extract upper 128 bits
-    let sum_high = _mm256_extracti128_si256::<1>(sum2);
-    // Add lower and upper 128-bit results
-    let result = _mm_add_epi32(sum_low, sum_high);
-    // Extract the final sum
-    _mm_cvtsi128_si32(result) as u32
-}
-
-#[target_feature(enable = "avx2")]
-unsafe fn accumulate_u64(x: __m256i) -> u64 {
-    let zero = _mm256_setzero_si256();
-    // Unpack to 64-bit integers
-    let sum_low = _mm256_unpacklo_epi32(x, zero);
-    let sum_high = _mm256_unpackhi_epi32(x, zero);
-    // Add the low and high parts
-    let sum = _mm256_add_epi64(sum_low, sum_high);
-    // Extract lower and upper 128-bit lanes
-    let sum_low = _mm256_extracti128_si256::<0>(sum);
-    let sum_high = _mm256_extracti128_si256::<1>(sum);
-    // Add the low and high 128-bit lanes
-    let sum = _mm_add_epi64(sum_low, sum_high);
-    // Extract and add the two 64-bit integers
-    _mm_extract_epi64(sum, 0) as u64 + _mm_extract_epi64(sum, 1) as u64
-}
+#[cfg(target_arch = "x86_64")]
+use x86_64::*;
 
 pub fn dot_product_f32_chunk(src: &[(f32, f32)], dst: &mut [f32]) -> f32 {
     let mut d: f32 = 0.0;
@@ -116,6 +31,7 @@ pub fn dot_product_f32_chunk(src: &[(f32, f32)], dst: &mut [f32]) -> f32 {
 
     d
 }
+
 pub fn dot_product_u8_chunk(src: &[(u8, u8)]) -> u64 {
     let mut d: u64 = 0;
     let chunk_size = 8;
@@ -141,17 +57,18 @@ pub fn dot_product_u8_chunk(src: &[(u8, u8)]) -> u64 {
 
     d
 }
+
 pub fn dot_product_a(src: &[(f32, f32)], dst: &mut [f32]) -> f32 {
     let mut d: f32 = 0.0;
     for (dst_sample, src_sample) in dst.iter_mut().zip(src.iter()) {
-        d += (src_sample.0 * src_sample.1);
+        d += src_sample.0 * src_sample.1;
     }
     d
 }
 
 pub fn dot_product_b(src: &[(f32, f32)], dst: &mut [f32]) {
     for (dst_sample, src_sample) in dst.iter_mut().zip(src.iter()) {
-        *dst_sample = (src_sample.0 * src_sample.1);
+        *dst_sample = src_sample.0 * src_sample.1;
     }
 }
 
@@ -163,6 +80,7 @@ pub fn dot_product_u8(src: &[(u8, u8)]) -> u64 {
 mod tests {
     use super::*;
     use rand::Rng;
+
     #[test]
     fn test_dot_product_functions() {
         let sizes = [32, 64, 128, 1024, 2048]; //, 64, 100, 128, 256, 500, 1000, 1024, 2048];
@@ -201,15 +119,24 @@ mod tests {
             let mut dst_f32 = vec![0.0; size];
 
             // Test u8 functions
-            let result_avx2 = unsafe { dot_product_u8_avx2(&a_u8, &b_u8) };
+            println!("Size: {}", size);
+
             let result_u8_chunk = dot_product_u8_chunk(&ab_u8);
             let result_u8_scalar = dot_product_u8(&ab_u8);
-            println!("Size: {}", size);
             println!("u8 results:");
-
-            println!("  AVX2:       {}", result_avx2);
             println!("  Chunk:      {}", result_u8_chunk);
             println!("  Scalar:     {}", result_u8_scalar);
+            #[cfg(target_arch = "x86_64")]
+            {
+                let result_avx2 = unsafe { x86_64::dot_product_u8_avx2(&a_u8, &b_u8) };
+                println!("  AVX2:       {}", result_avx2);
+            }
+            #[cfg(target_arch = "aarch64")]
+            {
+                let result_avx2 = unsafe { arm64::dot_product_u8_neon(&a_u8, &b_u8) };
+                println!("  NEON:       {}", result_avx2);
+            }
+
             // assert_eq!(
             //     result_fma, result_avx2,
             //     "Results differ for u8 AVX2 FMA vs AVX2 for size {}",

--- a/src/models/dot_product/arm64.rs
+++ b/src/models/dot_product/arm64.rs
@@ -1,0 +1,49 @@
+use std::arch::aarch64::*;
+
+fn print_uint8x16_t(name: &str, value: uint8x16_t) {
+    let mut array = [0u8; 32];
+    unsafe {
+        vst1q_u8(array.as_mut_ptr() as *mut u8, value);
+    }
+    print!("{} = [", name);
+    for (i, &byte) in array.iter().enumerate() {
+        if i > 0 {
+            print!(", ");
+        }
+        print!("{:3}", byte);
+    }
+    println!("]");
+}
+
+#[target_feature(enable = "neon")]
+pub unsafe fn dot_product_u8_neon(a: &[u8], b: &[u8]) -> u64 {
+    assert_eq!(a.len(), b.len());
+    let len = a.len();
+
+    const CHUNK_SIZE: usize = 16;
+
+    let mut sum = vdupq_n_u16(0);
+    let mut i = 0;
+
+    while i + CHUNK_SIZE <= len {
+        // Load 16 bytes from each slice into NEON registers
+        let a_chunk = vld1q_u8(a.as_ptr().add(i));
+        let b_chunk = vld1q_u8(b.as_ptr().add(i));
+
+        // Multiply and accumulate lower 8 bytes
+        sum = vmlal_u8(sum, vget_low_u8(a_chunk), vget_low_u8(b_chunk));
+        // Multiply and accumulate higher 8 bytes
+        sum = vmlal_u8(sum, vget_high_u8(a_chunk), vget_high_u8(b_chunk));
+        i += CHUNK_SIZE;
+    }
+
+    // Horizontally add the elements of the sum vector
+    let mut result = unsafe { vaddlvq_u32(vpaddlq_u16(sum)) };
+
+    // Process remaining elements
+    for j in i..a.len() {
+        result += (a[j] as u64) * (b[j] as u64);
+    }
+
+    result
+}

--- a/src/models/dot_product/x86_64.rs
+++ b/src/models/dot_product/x86_64.rs
@@ -1,0 +1,97 @@
+use rand::Rng;
+use std::arch::x86_64::*;
+
+fn print_mm256i(name: &str, value: __m256i) {
+    let mut array = [0u8; 32];
+    unsafe {
+        _mm256_storeu_si256(array.as_mut_ptr() as *mut __m256i, value);
+    }
+    print!("{} = [", name);
+    for (i, &byte) in array.iter().enumerate() {
+        if i > 0 {
+            print!(", ");
+        }
+        print!("{:3}", byte);
+    }
+    println!("]");
+}
+
+#[target_feature(enable = "avx2")]
+pub unsafe fn dot_product_u8_avx2(a: &[u8], b: &[u8]) -> u64 {
+    assert_eq!(a.len(), b.len());
+
+    let mut dot_product: u64 = 0;
+    let len = a.len();
+    let chunk_size = 32;
+
+    let mut sumlo = _mm256_setzero_si256();
+    let mut sumhi = _mm256_setzero_si256();
+    // Process 32 elements at a time
+    let mut i = 0;
+    while i + chunk_size <= len {
+        // Load 32 elements from each array into AVX2 registers
+        let va = _mm256_loadu_si256(a.as_ptr().add(i) as *const __m256i);
+        let vb = _mm256_loadu_si256(b.as_ptr().add(i) as *const __m256i);
+
+        // Unpack 8-bit integers to 16-bit integers
+        let va_lo = _mm256_unpacklo_epi8(va, _mm256_setzero_si256());
+        let va_hi = _mm256_unpackhi_epi8(va, _mm256_setzero_si256());
+        let vb_lo = _mm256_unpacklo_epi8(vb, _mm256_setzero_si256());
+        let vb_hi = _mm256_unpackhi_epi8(vb, _mm256_setzero_si256());
+
+        // print_mm256i("va_lo", va_lo);
+
+        // Multiply and add packed 16-bit integers
+        let prod_lo = _mm256_madd_epi16(va_lo, vb_lo);
+        let prod_hi = _mm256_madd_epi16(va_hi, vb_hi);
+        // print_mm256i("prod_lo", prod_lo);
+
+        sumlo = _mm256_add_epi32(sumlo, prod_lo);
+        sumhi = _mm256_add_epi32(sumhi, prod_hi);
+
+        i += chunk_size;
+    }
+
+    dot_product += accumulate_u32(sumlo) as u64;
+    dot_product += accumulate_u32(sumhi) as u64;
+
+    // Handle remaining elements
+    while i < len {
+        dot_product += a[i] as u64 * b[i] as u64;
+        i += 1;
+    }
+    dot_product
+}
+
+#[target_feature(enable = "avx2")]
+unsafe fn accumulate_u32(x: __m256i) -> u32 {
+    // Horizontal add within 256-bit lanes
+    let sum1 = _mm256_hadd_epi32(x, x);
+    // Horizontal add again
+    let sum2 = _mm256_hadd_epi32(sum1, sum1);
+    // Extract lower 128 bits
+    let sum_low = _mm256_castsi256_si128(sum2);
+    // Extract upper 128 bits
+    let sum_high = _mm256_extracti128_si256::<1>(sum2);
+    // Add lower and upper 128-bit results
+    let result = _mm_add_epi32(sum_low, sum_high);
+    // Extract the final sum
+    _mm_cvtsi128_si32(result) as u32
+}
+
+#[target_feature(enable = "avx2")]
+unsafe fn accumulate_u64(x: __m256i) -> u64 {
+    let zero = _mm256_setzero_si256();
+    // Unpack to 64-bit integers
+    let sum_low = _mm256_unpacklo_epi32(x, zero);
+    let sum_high = _mm256_unpackhi_epi32(x, zero);
+    // Add the low and high parts
+    let sum = _mm256_add_epi64(sum_low, sum_high);
+    // Extract lower and upper 128-bit lanes
+    let sum_low = _mm256_extracti128_si256::<0>(sum);
+    let sum_high = _mm256_extracti128_si256::<1>(sum);
+    // Add the low and high 128-bit lanes
+    let sum = _mm_add_epi64(sum_low, sum_high);
+    // Extract and add the two 64-bit integers
+    _mm_extract_epi64(sum, 0) as u64 + _mm_extract_epi64(sum, 1) as u64
+}


### PR DESCRIPTION
## Work done:
- Separate ARM and x86 implementations and allow the project to build on ARM platforms.
- Looked into Neon ISA and what is portable/available across all ARM platforms.
- Implement the dot product with multiply-add for Neon. 


## Not done:
- Common and benchmark examples haven't been implemented.