### PR TITLE
Add optional support for http mode (w/o TLS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,14 @@ cargo build --release
 
 ### Self Signed Certificates
 
-While developing Cosdata, you can use self-signed certificates for
-testing the APIs. The paths to the certificate and priviate key files
-are configured in the [config.toml](config.toml) file.
+It's recommended to run Cosdata server in HTTPS mode i.e. with TLS
+support. However, during development it might be easier to get it
+running without TLS. To do so, set `server.mode=http` in the
+[config.toml](config.toml) file.
+
+Alternately, you may use self-signed certificates for testing the
+APIs. The paths to the certificate and private key files are
+configured in the [config.toml](config.toml) file.
 
 This sections mentions how you can generate and setup the
 certificates.

--- a/README.md
+++ b/README.md
@@ -33,9 +33,14 @@ Build the project:
 cargo build --release
 ```
 
-### Self Signed Cerficates
+### Self Signed Certificates
 
-While developing Cosdata, you can use self-signed certificates for testing the APIs, this sections mentions how you can generate and setup them.
+While developing Cosdata, you can use self-signed certificates for
+testing the APIs. The paths to the certificate and priviate key files
+are configured in the [config.toml](config.toml) file.
+
+This sections mentions how you can generate and setup the
+certificates.
 
 #### Generate Certificates
 
@@ -60,13 +65,14 @@ Move certificates to appropriate folders and set permissions:
 
 ```bash
 # Create directories if don't exist
-sudo mkdir -p $SSL_CERT_DIR
-sudo mkdir -p $SSL_CERT_DIR/certs
-sudo mkdir -p $SSL_CERT_DIR/private
+sudo mkdir -p $SSL_CERT_DIR/{certs,private}
 
 # Move certificates
 sudo mv self_signed_certificate.crt $SSL_CERT_DIR/certs/cosdata-ssl.crt
 sudo mv private_key_pkcs8.pem $SSL_CERT_DIR/private/cosdata-ssl.key
+
+# Create 'ssl-cert' group (if if doesn't exist already)
+sudo groupadd ssl-cert
 
 # Change private key file permissions
 sudo chgrp ssl-cert $SSL_CERT_DIR/private/cosdata-ssl.key

--- a/config.toml
+++ b/config.toml
@@ -3,5 +3,5 @@ upload_process_batch_size = 1000
 
 [server]
 host = "127.0.0.1"
-port= "8443"
+port= 8443
 

--- a/config.toml
+++ b/config.toml
@@ -5,3 +5,7 @@ upload_process_batch_size = 1000
 host = "127.0.0.1"
 port= 8443
 
+[server.ssl]
+cert_file = "/etc/ssl/certs/cosdata-ssl.crt"
+key_file = "/etc/ssl/private/cosdata-ssl.key"
+

--- a/config.toml
+++ b/config.toml
@@ -4,6 +4,7 @@ upload_process_batch_size = 1000
 [server]
 host = "127.0.0.1"
 port= 8443
+mode = "https"   # Options: "http" or "https"
 
 [server.ssl]
 cert_file = "/etc/ssl/certs/cosdata-ssl.crt"

--- a/src/config_loader.rs
+++ b/src/config_loader.rs
@@ -11,13 +11,12 @@ pub struct Config {
 #[derive(Deserialize, Clone)]
 pub struct Server {
    pub host: String,
-   pub port: String
+   pub port: u16
 }
 
 pub fn load_config() -> Config {
     let config_contents = fs::read_to_string("config.toml").expect("Failed to load config file");
     let config: Config = toml::from_str(&config_contents).expect("Failed to parse config file contents!");
-    
     config
 }
 

--- a/src/config_loader.rs
+++ b/src/config_loader.rs
@@ -1,17 +1,24 @@
 use serde::Deserialize;
-use std::fs;
+use std::{fs, path::PathBuf};
 
 #[derive(Deserialize, Clone)]
 pub struct Config {
-   pub server: Server,
-   pub upload_threshold: u32, 
-   pub upload_process_batch_size: usize
+    pub server: Server,
+    pub upload_threshold: u32,
+    pub upload_process_batch_size: usize
+}
+
+#[derive(Deserialize, Clone)]
+pub struct Ssl {
+    pub cert_file: PathBuf,
+    pub key_file: PathBuf,
 }
 
 #[derive(Deserialize, Clone)]
 pub struct Server {
-   pub host: String,
-   pub port: u16
+    pub host: String,
+    pub port: u16,
+    pub ssl: Ssl,
 }
 
 pub fn load_config() -> Config {

--- a/src/config_loader.rs
+++ b/src/config_loader.rs
@@ -1,5 +1,7 @@
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
+use std::{io, vec};
 use std::{fs, path::PathBuf};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs};
 
 #[derive(Deserialize, Clone)]
 pub struct Config {
@@ -30,12 +32,98 @@ impl ServerMode {
     }
 }
 
+// Custom type for Host
+#[derive(Debug, Clone)]
+pub enum Host {
+    Ip(IpAddr),
+    Hostname(String),
+}
+
+impl std::fmt::Display for Host {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Host::Ip(ip) => ip.fmt(f),
+            Host::Hostname(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Host {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        if let Ok(address) = &s.parse::<Ipv6Addr>() {
+            return Ok(Host::Ip(IpAddr::V6(*address)));
+        }
+        if let Ok(address) = &s.parse::<Ipv4Addr>() {
+            return Ok(Host::Ip(IpAddr::V4(*address)));
+        }
+        Ok(Host::Hostname(s))
+    }
+}
+
+// Custom type for Port
+#[derive(Debug, Clone, Copy)]
+pub struct Port(u16);
+
+impl std::fmt::Display for Port {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// Conversion from/to raw port numbers
+impl From<u16> for Port {
+    fn from(port: u16) -> Self {
+        Port(port)
+    }
+}
+
+impl From<Port> for u16 {
+    fn from(port: Port) -> Self {
+        port.0
+    }
+}
+
+impl<'de> Deserialize<'de> for Port {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let number = u16::deserialize(d)?;
+        Ok(Self(number))
+    }
+}
+
+// Custom type that wraps Host and Port
+pub struct HostPort<'a>(&'a Host, &'a Port);
+
+// Implement ToSocketAddrs for the HostPort type
+impl<'a> ToSocketAddrs for HostPort<'a> {
+    type Iter = std::vec::IntoIter<SocketAddr>;
+
+    fn to_socket_addrs(&self) -> io::Result<Self::Iter> {
+        match &self.0 {
+            Host::Ip(ip) => {
+                let socket = SocketAddr::new(*ip, self.1.0);
+                Ok(vec![socket].into_iter())
+            }
+            Host::Hostname(hostname) => {
+                let addresses = (hostname.as_str(), self.1.0).to_socket_addrs()?;
+                Ok(addresses.collect::<Vec<_>>().into_iter())
+            }
+        }
+    }
+}
+
 #[derive(Deserialize, Clone)]
 pub struct Server {
-    pub host: String,
-    pub port: u16,
+    pub host: Host,
+    pub port: Port,
     pub ssl: Ssl,
     pub mode: ServerMode,
+}
+
+impl Server {
+    pub fn listen_address(&self) -> HostPort {
+        HostPort(&self.host, &self.port)
+    }
 }
 
 pub fn load_config() -> Config {

--- a/src/config_loader.rs
+++ b/src/config_loader.rs
@@ -15,10 +15,27 @@ pub struct Ssl {
 }
 
 #[derive(Deserialize, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum ServerMode {
+    Http,
+    Https,
+}
+
+impl ServerMode {
+    pub fn protocol(&self) -> &str {
+        match self {
+            Self::Http => "http",
+            Self::Https => "https",
+        }
+    }
+}
+
+#[derive(Deserialize, Clone)]
 pub struct Server {
     pub host: String,
     pub port: u16,
     pub ssl: Ssl,
+    pub mode: ServerMode,
 }
 
 pub fn load_config() -> Config {

--- a/src/web_server.rs
+++ b/src/web_server.rs
@@ -53,6 +53,7 @@ pub async fn run_actix_server() -> std::io::Result<()> {
     let config = load_config();
     let tls_config = load_rustls_config(&config.server.ssl);
     let config_data = Data::new(config);
+    let app_state = config_data.clone();
     log::info!("starting HTTPS server at https://{}", format!("{}:{}",&config_data.server.host, &config_data.server.port));
 
     HttpServer::new(move || {
@@ -103,7 +104,7 @@ pub async fn run_actix_server() -> std::io::Result<()> {
                             ),
                     ),
             )
-            .app_data(Data::new(load_config()).clone())
+            .app_data(app_state.clone())
 
         // .service(web::resource("/index").route(web::post().to(index)))
         // .service(

--- a/src/web_server.rs
+++ b/src/web_server.rs
@@ -12,7 +12,7 @@ use std::fs::create_dir_all;
 use std::path::Path;
 use std::sync::Arc;
 use std::{fs::File, io::BufReader};
-use cosdata::config_loader::{load_config, ServerMode, Ssl};
+use cosdata::config_loader::{load_config, ServerMode, Ssl, Host};
 use actix_web::web::Data;
 
 use crate::models::types::*;
@@ -130,10 +130,10 @@ pub async fn run_actix_server() -> std::io::Result<()> {
         // .service(web::resource("/").route(web::post().to(index)))
     });
 
-    let addr = (config_data.server.host.as_str(), config_data.server.port);
+    let addr = config_data.server.listen_address();
     let server = match tls {
-        Some(config) => server.bind_rustls_0_23(addr, config),
-        None => server.bind(addr)
+        Some(tls_config) => server.bind_rustls_0_23(addr, tls_config),
+        None => server.bind(addr),
     };
     server?
         .run()


### PR DESCRIPTION
The default continues to be https. Http mode is primarily meant for local development. But it could also be useful if the db is behind a reverse proxy that takes care of SSL. 

Besides the main change, this PR also includes a commit to load TLS config (paths to the certificate files) from `config.toml` file instead of an env var. 