### PR TITLE
ternary relationship example added in DSL spec

### DIFF
--- a/org/graph-datalog.org
+++ b/org/graph-datalog.org
@@ -165,9 +165,8 @@ define rule infer_management as
         ($employee, $dept) forms manages;
   #+end_src
 * Querying
-** Basic Query Structure
 
-Query
+** Basic Query Structure
 #+BEGIN_SRC c
 match
     $<variable> isa <entity_type> (
@@ -181,13 +180,8 @@ match
         <attribute_name>: <value_or_variable>
         [, <attribute_name>: <value_or_variable>]*
     )]*
-get $<variable> [, $<variable>]*
-[enlist];
+get $<variable> [, $<variable>]*;
 #+END_SRC
-
-Output Schema
- - a list of all the matches
-   - with the free variables optionally enlisted after the demanded ones
 
 Example (querying a ternary relationship):
 #+BEGIN_SRC c

--- a/org/graph-datalog.org
+++ b/org/graph-datalog.org
@@ -54,6 +54,16 @@ define relationship employment as
     salary: double;
 #+END_SRC
 
+Example (primitive ternary relationship)
+#+begin_src c
+// can't be decomposed into binaries
+define relationship contributes_research as
+    (author: person,
+     research_entity: research_entity, // survey, workshop, talk
+     domain: domain),
+    date: date; //in-exhaustive attrs
+#+end_src
+
 *** Note: Relationship Definitions (Schema Level):
 
 - These are like blueprints or templates for relationships.

--- a/org/graph-datalog.org
+++ b/org/graph-datalog.org
@@ -165,8 +165,9 @@ define rule infer_management as
         ($employee, $dept) forms manages;
   #+end_src
 * Querying
-
 ** Basic Query Structure
+
+Query
 #+BEGIN_SRC c
 match
     $<variable> isa <entity_type> (
@@ -180,8 +181,13 @@ match
         <attribute_name>: <value_or_variable>
         [, <attribute_name>: <value_or_variable>]*
     )]*
-get $<variable> [, $<variable>]*;
+get $<variable> [, $<variable>]*
+[enlist];
 #+END_SRC
+
+Output Schema
+ - a list of all the matches
+   - with the free variables optionally enlisted after the demanded ones
 
 Example (querying a ternary relationship):
 #+BEGIN_SRC c


### PR DESCRIPTION
adding a non-decomposable ternary relationship definition in the DSL spec
 - thought would be useful given we've these in examples later on