### PR TITLE
Reduce contention on inserting children into `InvertedIndexItem`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "arcshift"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d331936e5e395b6a3173357d302fbfea6077307cbc4e1c1a596814c1e74855"
+checksum = "623c657cd8b8cda80e942bdc4deedd4db812dded38f8940bd1a2fd77efeb8e55"
 
 [[package]]
 name = "async-channel"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ actix-cors = "0.7.0"
 actix-files = "0.6.5"
 actix-web = { version = "4.6.0", features = ["rustls-0_23"] }
 actix-web-httpauth = "0.8.1"
-arcshift = "0.1.7"
+arcshift = "0.1.9"
 async-channel = "2.3.1"
 async-std = "1.12.0"
 bincode = "1.3.3"

--- a/benches/inverted_index_benchmark.rs
+++ b/benches/inverted_index_benchmark.rs
@@ -67,8 +67,7 @@ fn benchmark_sequential_inserts(c: &mut Criterion) {
 
 fn benchmark_parallel_inserts(c: &mut Criterion) {
     let dimensions = 1000; // Increased dimensions
-                           // let vector_counts = [1000, 10000, 100000];
-    let vector_counts = [1000];
+    let vector_counts = [1000, 10000, 100000];
 
     let mut group = c.benchmark_group("Insert sparse vectors");
     group.sample_size(10);

--- a/benches/inverted_index_benchmark.rs
+++ b/benches/inverted_index_benchmark.rs
@@ -67,7 +67,7 @@ fn benchmark_sequential_inserts(c: &mut Criterion) {
 
 fn benchmark_parallel_inserts(c: &mut Criterion) {
     let dimensions = 1000; // Increased dimensions
-    let vector_counts = [1000, 10000, 100000];
+    let vector_counts = [1000, 10000, 100_000];
 
     let mut group = c.benchmark_group("Insert sparse vectors");
     group.sample_size(10);

--- a/benches/inverted_index_benchmark.rs
+++ b/benches/inverted_index_benchmark.rs
@@ -3,26 +3,24 @@ use std::collections::BTreeSet;
 use cosdata::storage::inverted_index::InvertedIndex;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use rand::{rngs::StdRng, Rng, SeedableRng};
+use rayon::prelude::*;
 
 // Function to generate multiple random sparse vectors
-fn generate_random_sparse_vectors(
-    num_records: usize,
-    max_index: usize,
-    min_nonzero: usize,
-    max_nonzero: usize,
-) -> Vec<Vec<f32>> {
+fn generate_random_sparse_vectors(num_records: usize, dimensions: usize) -> Vec<Vec<f32>> {
     let mut rng = StdRng::seed_from_u64(2024);
-    let mut records: Vec<Vec<f32>> = vec![];
+    let mut records: Vec<Vec<f32>> = Vec::with_capacity(num_records);
 
     for _ in 0..num_records {
-        let num_nonzero: usize = rng.gen_range(min_nonzero..=max_nonzero);
-        let mut record = vec![0.0; max_index];
+        let mut record = vec![0.0; dimensions];
+
+        // Calculate the number of non-zero elements (5% to 10% of dimensions)
+        let num_nonzero = rng
+            .gen_range((dimensions as f32 * 0.05) as usize..=(dimensions as f32 * 0.10) as usize);
 
         // BTreeSet is used to store unique indices of nonzero values in sorted order
         let mut unique_indices = BTreeSet::new();
-        while unique_indices.len() < num_nonzero as usize {
-            // Generate a random index
-            let index = rng.gen_range(0..max_index);
+        while unique_indices.len() < num_nonzero {
+            let index = rng.gen_range(0..dimensions);
             unique_indices.insert(index);
         }
 
@@ -37,34 +35,68 @@ fn generate_random_sparse_vectors(
     records
 }
 
-fn benchmark_inserts(c: &mut Criterion) {
-    let max_index = 10;
-    let num_vectors = 100;
-    let min_nonzero = 1;
-    let max_nonzero = 4;
+fn benchmark_sequential_inserts(c: &mut Criterion) {
+    let dimensions = 1000; // Increased dimensions
+    let vector_counts = [1000];
 
-    // Generate random sparse vectors
-    let records = generate_random_sparse_vectors(num_vectors, max_index, min_nonzero, max_nonzero);
+    let mut group = c.benchmark_group("Insert sparse vectors");
+    group.sample_size(10);
 
-    // Create new inverted index
-    let inverted_index: InvertedIndex<f32> = InvertedIndex::new();
+    for &num_vectors in &vector_counts {
+        // Generate random sparse vectors
+        let records = generate_random_sparse_vectors(num_vectors, dimensions);
 
-    let test_name = format!(
-        "Insert {} sparse vectors of dimensionality {}",
-        num_vectors, max_index
-    );
-    c.bench_with_input(
-        BenchmarkId::new(test_name, num_vectors),
-        &records,
-        |b, records| {
-            b.iter(|| {
-                for (id, record) in records.iter().enumerate() {
-                    let _ = inverted_index.add_sparse_vector(record.to_vec(), id as u32);
-                }
-            });
-        },
-    );
+        // Sequential benchmark
+        let seq_test_name = format!("Sequential {} vectors", num_vectors);
+        group.bench_with_input(
+            BenchmarkId::new(seq_test_name, num_vectors),
+            &records,
+            |b, records| {
+                b.iter(|| {
+                    let inverted_index: InvertedIndex<f32> = InvertedIndex::new();
+                    for (id, record) in records.iter().enumerate() {
+                        let _ = inverted_index.add_sparse_vector(record.to_vec(), id as u32);
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
 }
 
-criterion_group!(benches, benchmark_inserts);
+fn benchmark_parallel_inserts(c: &mut Criterion) {
+    let dimensions = 1000; // Increased dimensions
+                           // let vector_counts = [1000, 10000, 100000];
+    let vector_counts = [1000];
+
+    let mut group = c.benchmark_group("Insert sparse vectors");
+    group.sample_size(10);
+
+    for &num_vectors in &vector_counts {
+        // Generate random sparse vectors
+        let records = generate_random_sparse_vectors(num_vectors, dimensions);
+
+        // Parallel benchmark
+        let par_test_name = format!("Parallel {} vectors", num_vectors);
+        group.bench_with_input(
+            BenchmarkId::new(par_test_name, num_vectors),
+            &records,
+            |b, records| {
+                b.iter(|| {
+                    let inverted_index: InvertedIndex<f32> = InvertedIndex::new();
+                    records.par_iter().enumerate().for_each(|(id, record)| {
+                        let _ = inverted_index.add_sparse_vector(record.to_vec(), id as u32);
+                    });
+                });
+            },
+        );
+    }
+}
+
+criterion_group!(
+    benches,
+    // benchmark_sequential_inserts,
+    benchmark_parallel_inserts
+);
 criterion_main!(benches);

--- a/src/bin/inverted_index_main_flame.rs
+++ b/src/bin/inverted_index_main_flame.rs
@@ -36,7 +36,7 @@ fn generate_random_sparse_vectors(num_records: usize, dimensions: usize) -> Vec<
 
 fn main() {
     let dimensions = 1000; // Increased dimensions
-    let num_vectors = 10_000;
+    let num_vectors = 1000;
 
     // Generate random sparse vectors
     let records = generate_random_sparse_vectors(num_vectors, dimensions);

--- a/src/bin/inverted_index_main_flame.rs
+++ b/src/bin/inverted_index_main_flame.rs
@@ -1,0 +1,48 @@
+use std::collections::BTreeSet;
+
+use cosdata::storage::inverted_index::InvertedIndex;
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use rayon::prelude::*;
+
+// Function to generate multiple random sparse vectors
+fn generate_random_sparse_vectors(num_records: usize, dimensions: usize) -> Vec<Vec<f32>> {
+    let mut rng = StdRng::seed_from_u64(2024);
+    let mut records: Vec<Vec<f32>> = Vec::with_capacity(num_records);
+
+    for _ in 0..num_records {
+        let mut record = vec![0.0; dimensions];
+
+        // Calculate the number of non-zero elements (5% to 10% of dimensions)
+        let num_nonzero = rng
+            .gen_range((dimensions as f32 * 0.05) as usize..=(dimensions as f32 * 0.10) as usize);
+
+        // BTreeSet is used to store unique indices of nonzero values in sorted order
+        let mut unique_indices = BTreeSet::new();
+        while unique_indices.len() < num_nonzero {
+            let index = rng.gen_range(0..dimensions);
+            unique_indices.insert(index);
+        }
+
+        // Generate random values for the nonzero indices
+        for index in unique_indices {
+            record[index] = rng.gen();
+        }
+
+        records.push(record);
+    }
+
+    records
+}
+
+fn main() {
+    let dimensions = 1000; // Increased dimensions
+    let num_vectors = 10_000;
+
+    // Generate random sparse vectors
+    let records = generate_random_sparse_vectors(num_vectors, dimensions);
+
+    let inverted_index: InvertedIndex<f32> = InvertedIndex::new();
+    records.par_iter().enumerate().for_each(|(id, record)| {
+        let _ = inverted_index.add_sparse_vector(record.to_vec(), id as u32);
+    });
+}

--- a/src/models/lazy_load.rs
+++ b/src/models/lazy_load.rs
@@ -610,21 +610,27 @@ impl<T: Clone + 'static> LazyItemMap<T> {
 
     /// Inserts a new key value pair into the map if the key does not already exist
     ///
+    /// Return the new value if the key did not exist, otherwise return the existing value
+    ///
     /// Note: Concurrent updates should use checked_insert to avoid overwriting
     /// updates from other threads.
-    pub fn checked_insert(&self, key: IdentityMapKey, default: LazyItem<T>) {
+    pub fn checked_insert(&self, key: IdentityMapKey, default: LazyItem<T>) -> Option<LazyItem<T>> {
         let mut arc = self.items.clone();
 
-        arc.transactional_update(|map| {
-            let mut new_map = map.clone();
-            if !new_map.contains(&key) {
-                new_map.insert(key.clone(), default.clone());
-                new_map
-            } else {
-                new_map
-            }
-        })
-        .expect("Map update should succeed");
+        let (_, new_child) = arc.arcshift.rcu_project(
+            |map| {
+                (!map.contains(&key))
+                    .then(|| {
+                        let mut new_map = map.clone();
+                        new_map.insert(key.clone(), default.clone());
+                        Some(new_map)
+                    })
+                    .flatten()
+            },
+            |item| item.get(&key).map(|item| item.clone()),
+        );
+
+        new_child
     }
 
     pub fn get(&self, key: &IdentityMapKey) -> Option<LazyItem<T>> {

--- a/src/models/lazy_load.rs
+++ b/src/models/lazy_load.rs
@@ -584,7 +584,7 @@ impl<T: Clone + Identifiable<Id = u64> + 'static> LazyItemSet<T> {
 impl<T: Clone + 'static> LazyItemMap<T> {
     pub fn new() -> Self {
         Self {
-            items: STM::new(IdentityMap::new(), 1, true),
+            items: STM::new(IdentityMap::new(), 5, true),
         }
     }
 

--- a/src/models/types.rs
+++ b/src/models/types.rs
@@ -471,7 +471,7 @@ pub struct STM<T: 'static> {
 fn backoff(iteration: usize) {
     let spins = 1 << iteration;
     for _ in 0..spins {
-        spin_loop();
+        std::thread::yield_now();
     }
 }
 
@@ -528,8 +528,7 @@ where
                 }
 
                 // Apply backoff before the next retry attempt
-                // backoff(tries);
-                std::thread::yield_now();
+                backoff(tries);
                 tries += 1;
             }
         }

--- a/src/models/types.rs
+++ b/src/models/types.rs
@@ -463,7 +463,7 @@ pub fn get_app_env() -> Result<Arc<AppEnv>, WaCustomError> {
 
 #[derive(Clone)]
 pub struct STM<T: 'static> {
-    arcshift: ArcShift<T>,
+    pub arcshift: ArcShift<T>,
     max_retries: usize,
     strict: bool,
 }
@@ -528,7 +528,8 @@ where
                 }
 
                 // Apply backoff before the next retry attempt
-                backoff(tries);
+                // backoff(tries);
+                std::thread::yield_now();
                 tries += 1;
             }
         }

--- a/src/storage/inverted_index.rs
+++ b/src/storage/inverted_index.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::sync::{Arc, RwLock};
 
 use arcshift::ArcShift;
+use dashmap::DashMap;
 
 use crate::models::buffered_io::BufferManagerFactory;
 use crate::models::cache_loader::NodeRegistry;
@@ -56,7 +57,7 @@ where
 {
     pub dim_index: u32,
     pub implicit: bool,
-    pub data: LazyItemMap<T>,
+    pub data: Arc<DashMap<IdentityMapKey, LazyItem<T>>>,
     // TODO: benchmark if fixed size children array with lazy item refs
     //  yields better performance
     pub lazy_children: LazyItemMap<InvertedIndexItem<T>>,
@@ -99,7 +100,7 @@ where
         InvertedIndexItem {
             dim_index,
             implicit,
-            data: LazyItemMap::new(),
+            data: Arc::new(DashMap::new()),
             lazy_children: LazyItemMap::new(),
         }
     }

--- a/src/storage/inverted_index.rs
+++ b/src/storage/inverted_index.rs
@@ -116,14 +116,15 @@ where
             let new_dim_index = current_node.dim_index + POWERS_OF_4[child_index];
             let key = IdentityMapKey::Int(child_index as u32);
             let new_child = LazyItem::new(0.into(), InvertedIndexItem::new(new_dim_index, true));
-            current_node
-                .lazy_children
-                .checked_insert(key.clone(), new_child);
-            current_node = current_node
-                .lazy_children
-                .get(&key)
-                .map(|lazy_item| lazy_item.get_data(cache.clone()))
-                .expect("Child should exist");
+            loop {
+                if let Some(child) = current_node
+                    .lazy_children
+                    .checked_insert(key.clone(), new_child.clone())
+                {
+                    current_node = child.get_data(cache.clone());
+                    break;
+                }
+            }
         }
 
         current_node


### PR DESCRIPTION
On benchmarking the current implementation we found the following problems -
* Heavy contention on loops that for writing data into `ArcShift` for adding new children to inverted index
* Copying of huge amount of memory for writing dimension values into data field of inverted index item

---

The first problem has been solved by using `rcu_project` present in the latest `arcshift` release. It allows us to conditionally update the value and project something from the underlying value. This allows us to transactionally update and read from the arcshift data. It is ideal for `create_or_insert` child function needed to traverse the inverted index dag. These are the key properties -

1. Maybe update
    1. if a child exists don't add anything
    2. if it doesn't exists try to add a new default child
2. Project
     1. Irrespective of whether the previous steps failed or succeeded, get a child for the given key from the map and return an optional child

If the returned child is None, we retry the above steps again.

Note: A point to consider is using different data structure for storing children. Since it is known that children for each node will not exceed 16 (4^16 is 3 billion dimensions). A non-growable, statically sized array that stores optional items for non-existent children might be a better choice.

---

The problem of large amount of data copies is fundamental to ArcShift design. It works by cloning the internal data, updating and than replacing it in inside the archshift in single atomic update. However, for the data field which can store thousands of values, this means copying a thousand values for each subsequent insert. In fact, this eats up memory so fast that inserting 100k nodes is not possible on my machine.

Here we can't afford cloning existing data so we must use a lock-based solution to concurrent update a map. For this a Dashmap is a good fit and testing it out in the below changes yields good results.

---

This PR also adds a main function to insert large amounts of data into the inverted index for flaemgraphing use. It also updates the benchmarks with different variations of the test.

The random vector generator is also updated to take as input the number of vectors to produce, the dimensions of the vectors and internally it populates between 5-10% of the dimensions with non-zero values.