### PR TITLE
Modify benchmark to insert (dim, val) pairs

### DIFF
--- a/benches/inverted_index_benchmark.rs
+++ b/benches/inverted_index_benchmark.rs
@@ -5,17 +5,27 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use rayon::prelude::*;
 
+struct SparseVector {
+    vector_id: u32,
+    entries: Vec<(u32, f32)>,
+}
+
+impl SparseVector {
+    fn new(vector_id: u32, entries: Vec<(u32, f32)>) -> Self {
+        Self { vector_id, entries }
+    }
+}
+
 // Function to generate multiple random sparse vectors
-fn generate_random_sparse_vectors(num_records: usize, dimensions: usize) -> Vec<Vec<f32>> {
+fn generate_random_sparse_vectors(num_records: usize, dimensions: usize) -> Vec<SparseVector> {
     let mut rng = StdRng::seed_from_u64(2024);
-    let mut records: Vec<Vec<f32>> = Vec::with_capacity(num_records);
+    let mut records: Vec<SparseVector> = Vec::with_capacity(num_records);
 
-    for _ in 0..num_records {
-        let mut record = vec![0.0; dimensions];
-
+    for vector_id in 0..num_records {
         // Calculate the number of non-zero elements (5% to 10% of dimensions)
         let num_nonzero = rng
             .gen_range((dimensions as f32 * 0.05) as usize..=(dimensions as f32 * 0.10) as usize);
+        let mut entries: Vec<(u32, f32)> = Vec::with_capacity(num_nonzero);
 
         // BTreeSet is used to store unique indices of nonzero values in sorted order
         let mut unique_indices = BTreeSet::new();
@@ -25,11 +35,12 @@ fn generate_random_sparse_vectors(num_records: usize, dimensions: usize) -> Vec<
         }
 
         // Generate random values for the nonzero indices
-        for index in unique_indices {
-            record[index] = rng.gen();
+        for dim_index in unique_indices {
+            let value = rng.gen();
+            entries.push((dim_index as u32, value));
         }
 
-        records.push(record);
+        records.push(SparseVector::new(vector_id as u32, entries));
     }
 
     records
@@ -54,8 +65,10 @@ fn benchmark_sequential_inserts(c: &mut Criterion) {
             |b, records| {
                 b.iter(|| {
                     let inverted_index: InvertedIndex<f32> = InvertedIndex::new();
-                    for (id, record) in records.iter().enumerate() {
-                        let _ = inverted_index.add_sparse_vector(record.to_vec(), id as u32);
+                    for record in records.iter() {
+                        for entry in record.entries.iter() {
+                            let _ = inverted_index.insert(entry.0, entry.1, record.vector_id);
+                        }
                     }
                 });
             },
@@ -84,8 +97,11 @@ fn benchmark_parallel_inserts(c: &mut Criterion) {
             |b, records| {
                 b.iter(|| {
                     let inverted_index: InvertedIndex<f32> = InvertedIndex::new();
-                    records.par_iter().enumerate().for_each(|(id, record)| {
-                        let _ = inverted_index.add_sparse_vector(record.to_vec(), id as u32);
+                    records.par_iter().for_each(|record| {
+                        let vector_id = record.vector_id;
+                        record.entries.iter().for_each(|entry| {
+                            let _ = inverted_index.insert(entry.0, entry.1, vector_id);
+                        });
                     });
                 });
             },

--- a/benches/inverted_index_benchmark.rs
+++ b/benches/inverted_index_benchmark.rs
@@ -1,20 +1,9 @@
 use std::collections::BTreeSet;
 
-use cosdata::storage::inverted_index::InvertedIndex;
+use cosdata::{models::types::SparseVector, storage::inverted_index::InvertedIndex};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use rayon::prelude::*;
-
-struct SparseVector {
-    vector_id: u32,
-    entries: Vec<(u32, f32)>,
-}
-
-impl SparseVector {
-    fn new(vector_id: u32, entries: Vec<(u32, f32)>) -> Self {
-        Self { vector_id, entries }
-    }
-}
 
 // Function to generate multiple random sparse vectors
 fn generate_random_sparse_vectors(num_records: usize, dimensions: usize) -> Vec<SparseVector> {
@@ -98,10 +87,7 @@ fn benchmark_parallel_inserts(c: &mut Criterion) {
                 b.iter(|| {
                     let inverted_index: InvertedIndex<f32> = InvertedIndex::new();
                     records.par_iter().for_each(|record| {
-                        let vector_id = record.vector_id;
-                        record.entries.iter().for_each(|entry| {
-                            let _ = inverted_index.insert(entry.0, entry.1, vector_id);
-                        });
+                        let _ = inverted_index.add_sparse_vector(record.clone());
                     });
                 });
             },

--- a/src/models/types.rs
+++ b/src/models/types.rs
@@ -536,3 +536,15 @@ where
         Ok(updated)
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct SparseVector {
+    pub vector_id: u32,
+    pub entries: Vec<(u32, f32)>,
+}
+
+impl SparseVector {
+    pub fn new(vector_id: u32, entries: Vec<(u32, f32)>) -> Self {
+        Self { vector_id, entries }
+    }
+}


### PR DESCRIPTION
- Modify inverted index benchmark to insert `(dimension, value)` pairs for non-zero indices, instead of `Vec<f32>`
- Create new `SparseVector` datatype. Change `InvertedIndex::add_sparse_vector()` to directly process `SparseVector`