### PR TITLE
feat: make cache more generic

### DIFF
--- a/src/models/cache_loader.rs
+++ b/src/models/cache_loader.rs
@@ -1,4 +1,6 @@
 use crate::models::lru_cache::CachedValue;
+use crate::storage::inverted_index::InvertedIndexItem;
+use crate::storage::Storage;
 
 use super::buffered_io::{BufIoError, BufferManagerFactory};
 use super::file_persist::*;
@@ -13,9 +15,48 @@ use std::io;
 use std::path::Path;
 use std::sync::{atomic::AtomicBool, Arc, RwLock};
 
+#[derive(Clone)]
+pub enum CacheItem {
+    MergedNode(LazyItem<MergedNode>),
+    InvertedIndexItem(LazyItem<InvertedIndexItem<Storage>>),
+}
+
+pub trait Cacheable: Clone + 'static {
+    fn from_cache_item(cache_item: CacheItem) -> Option<LazyItem<Self>>;
+    fn into_cache_item(item: LazyItem<Self>) -> CacheItem;
+}
+
+impl Cacheable for MergedNode {
+    fn from_cache_item(cache_item: CacheItem) -> Option<LazyItem<Self>> {
+        if let CacheItem::MergedNode(item) = cache_item {
+            Some(item)
+        } else {
+            None
+        }
+    }
+
+    fn into_cache_item(item: LazyItem<Self>) -> CacheItem {
+        CacheItem::MergedNode(item)
+    }
+}
+
+impl Cacheable for InvertedIndexItem<Storage> {
+    fn from_cache_item(cache_item: CacheItem) -> Option<LazyItem<Self>> {
+        if let CacheItem::InvertedIndexItem(item) = cache_item {
+            Some(item)
+        } else {
+            None
+        }
+    }
+
+    fn into_cache_item(item: LazyItem<Self>) -> CacheItem {
+        CacheItem::InvertedIndexItem(item)
+    }
+}
+
 pub struct NodeRegistry {
     cuckoo_filter: RwLock<CuckooFilter<u64>>,
-    registry: LRUCache<u64, LazyItem<MergedNode>>,
+    registry: LRUCache<u64, CacheItem>,
     bufmans: Arc<BufferManagerFactory>,
 }
 
@@ -29,13 +70,13 @@ impl NodeRegistry {
             bufmans,
         }
     }
-    pub fn get_object<F>(
+    pub fn get_object<T: Cacheable, F>(
         self: Arc<Self>,
         file_index: FileIndex,
         load_function: F,
         max_loads: u16,
         skipm: &mut HashSet<u64>,
-    ) -> Result<LazyItem<MergedNode>, BufIoError>
+    ) -> Result<LazyItem<T>, BufIoError>
     where
         F: Fn(
             Arc<BufferManagerFactory>,
@@ -43,7 +84,7 @@ impl NodeRegistry {
             Arc<Self>,
             u16,
             &mut HashSet<u64>,
-        ) -> Result<LazyItem<MergedNode>, BufIoError>,
+        ) -> Result<LazyItem<T>, BufIoError>,
     {
         println!(
             "get_object called with file_index: {:?}, max_loads: {}",
@@ -60,8 +101,10 @@ impl NodeRegistry {
             if cuckoo_filter.contains(&combined_index) {
                 println!("FileIndex found in cuckoo_filter");
                 if let Some(obj) = self.registry.get(&combined_index) {
-                    println!("Object found in registry, returning");
-                    return Ok(obj.clone());
+                    if let Some(item) = T::from_cache_item(obj) {
+                        println!("Object found in registry, returning");
+                        return Ok(item);
+                    }
                 } else {
                     println!("Object not found in registry despite being in cuckoo_filter");
                 }
@@ -101,21 +144,21 @@ impl NodeRegistry {
         println!("load_function returned successfully");
 
         println!("Trying to get or insert item into registry");
-        let cached_item = self.registry.get_or_insert::<BufIoError>(combined_index.clone(), || {
-            Ok(item)
-        })?;
+        let cached_item = self
+            .registry
+            .get_or_insert::<BufIoError>(combined_index.clone(), || Ok(T::into_cache_item(item)))?;
 
         match cached_item {
             CachedValue::Hit(item) => {
                 println!("Object found in registry after load, returning");
-                Ok(item)
+                Ok(T::from_cache_item(item).unwrap())
             }
             CachedValue::Miss(item) => {
                 println!("Inserting key into cuckoo_filter");
                 self.cuckoo_filter.write().unwrap().insert(&combined_index);
 
                 println!("Returning newly created LazyItem");
-                Ok(item)
+                Ok(T::from_cache_item(item).unwrap())
             }
         }
     }

--- a/src/models/serializer/eager_lazy_item.rs
+++ b/src/models/serializer/eager_lazy_item.rs
@@ -1,7 +1,7 @@
 use super::CustomSerialize;
 use crate::models::{
     buffered_io::{BufIoError, BufferManagerFactory},
-    cache_loader::NodeRegistry,
+    cache_loader::{Cacheable, NodeRegistry},
     lazy_load::{EagerLazyItem, FileIndex, LazyItem, SyncPersist},
     types::FileOffset,
     versioning::Hash,
@@ -12,8 +12,7 @@ use std::sync::Arc;
 
 impl<T, E> CustomSerialize for EagerLazyItem<T, E>
 where
-    T: Clone + 'static,
-    LazyItem<T>: CustomSerialize,
+    T: Cacheable + CustomSerialize + Clone + 'static,
     E: Clone + CustomSerialize + 'static,
 {
     fn serialize(

--- a/src/models/serializer/eager_lazy_item_set.rs
+++ b/src/models/serializer/eager_lazy_item_set.rs
@@ -1,9 +1,9 @@
 use super::CustomSerialize;
 use crate::models::{
     buffered_io::{BufIoError, BufferManagerFactory},
-    cache_loader::NodeRegistry,
+    cache_loader::{Cacheable, NodeRegistry},
     identity_collections::{Identifiable, IdentitySet},
-    lazy_load::{EagerLazyItem, EagerLazyItemSet, FileIndex, LazyItem, CHUNK_SIZE},
+    lazy_load::{EagerLazyItem, EagerLazyItemSet, FileIndex, CHUNK_SIZE},
     types::FileOffset,
     versioning::Hash,
 };
@@ -12,8 +12,7 @@ use std::{io::SeekFrom, sync::Arc};
 
 impl<T, E> CustomSerialize for EagerLazyItemSet<T, E>
 where
-    LazyItem<T>: CustomSerialize,
-    T: Clone + Identifiable<Id = u64> + 'static,
+    T: Cacheable + CustomSerialize + Clone + Identifiable<Id = u64> + 'static,
     E: Clone + CustomSerialize + 'static,
 {
     fn serialize(

--- a/src/models/serializer/lazy_item_map.rs
+++ b/src/models/serializer/lazy_item_map.rs
@@ -1,13 +1,10 @@
 use super::CustomSerialize;
 use crate::models::buffered_io::{BufIoError, BufferManagerFactory};
+use crate::models::cache_loader::{Cacheable, NodeRegistry};
 use crate::models::identity_collections::{IdentityMap, IdentityMapKey};
-use crate::models::lazy_load::{FileIndex, LazyItemMap, SyncPersist};
+use crate::models::lazy_load::{FileIndex, LazyItem, LazyItemMap, SyncPersist, CHUNK_SIZE};
 use crate::models::types::FileOffset;
 use crate::models::versioning::Hash;
-use crate::models::{
-    cache_loader::NodeRegistry,
-    lazy_load::{LazyItem, CHUNK_SIZE},
-};
 use std::collections::HashSet;
 use std::{
     io::{self, SeekFrom},
@@ -18,8 +15,7 @@ const MSB: u32 = 1 << 31;
 
 impl<T> CustomSerialize for LazyItemMap<T>
 where
-    T: Clone + CustomSerialize + 'static,
-    LazyItem<T>: CustomSerialize,
+    T: Cacheable + Clone + CustomSerialize + 'static,
 {
     fn serialize(
         &self,

--- a/src/models/serializer/lazy_item_set.rs
+++ b/src/models/serializer/lazy_item_set.rs
@@ -1,7 +1,7 @@
 use super::CustomSerialize;
 use crate::models::{
     buffered_io::{BufIoError, BufferManagerFactory},
-    cache_loader::NodeRegistry,
+    cache_loader::{Cacheable, NodeRegistry},
     identity_collections::{Identifiable, IdentitySet},
     lazy_load::{FileIndex, LazyItem, LazyItemSet, SyncPersist, CHUNK_SIZE},
     types::FileOffset,
@@ -12,8 +12,7 @@ use std::{io::SeekFrom, sync::Arc};
 
 impl<T> CustomSerialize for LazyItemSet<T>
 where
-    T: Clone + Identifiable<Id = u64> + CustomSerialize + 'static,
-    LazyItem<T>: CustomSerialize,
+    T: Cacheable + Clone + Identifiable<Id = u64> + CustomSerialize + 'static,
 {
     fn serialize(
         &self,

--- a/src/models/serializer/lazy_item_vec.rs
+++ b/src/models/serializer/lazy_item_vec.rs
@@ -1,7 +1,7 @@
 use super::CustomSerialize;
 use crate::models::{
     buffered_io::{BufIoError, BufferManagerFactory},
-    cache_loader::NodeRegistry,
+    cache_loader::{Cacheable, NodeRegistry},
     lazy_load::{FileIndex, LazyItem, LazyItemVec, SyncPersist, CHUNK_SIZE},
     types::FileOffset,
     versioning::Hash,
@@ -11,8 +11,7 @@ use std::{io::SeekFrom, sync::Arc};
 
 impl<T> CustomSerialize for LazyItemVec<T>
 where
-    T: Clone + CustomSerialize + 'static,
-    LazyItem<T>: CustomSerialize,
+    T: Cacheable + CustomSerialize + Clone + CustomSerialize + 'static,
 {
     fn serialize(
         &self,


### PR DESCRIPTION
Used an enum to allow `InvertedIndexItem<Storage>` and `MergedNode` to be cached, other types can also be easily added when needed