### PR TITLE
Create incrementally serializable growable collection

### DIFF
--- a/src/models/serializer/incremental_serializable_growable_data.rs
+++ b/src/models/serializer/incremental_serializable_growable_data.rs
@@ -53,8 +53,8 @@ impl CustomSerialize for IncrementalSerializableGrowableData {
                 continue;
             }
 
-            // TODO: Correctly serialize the version
-            bufman.write_u32_with_cursor(cursor, 0u32)?;
+            // Serialize the version
+            bufman.write_u32_with_cursor(cursor, **version)?;
 
             // Serialize the array
             for i in 0..64 {
@@ -96,7 +96,6 @@ impl CustomSerialize for IncrementalSerializableGrowableData {
                 for _ in 0..total_items {
                     let mut item = [u32::MAX; 64];
                     // Deserialize version
-                    // TODO: Correctly deserialize the version
                     let version = bufman.read_u32_with_cursor(cursor)?;
 
                     // Deserialize elements

--- a/src/models/serializer/mod.rs
+++ b/src/models/serializer/mod.rs
@@ -1,6 +1,7 @@
 mod dashmap;
 mod eager_lazy_item;
 mod eager_lazy_item_set;
+mod incremental_serializable_growable_data;
 mod inverted_index;
 mod inverted_index_item;
 mod inverted_index_sparse_ann_node;
@@ -11,7 +12,6 @@ mod lazy_item_set;
 mod lazy_item_vec;
 mod metric_distance;
 mod neighbour;
-mod new_struct;
 mod node;
 mod storage;
 mod vector;

--- a/src/models/serializer/mod.rs
+++ b/src/models/serializer/mod.rs
@@ -11,6 +11,7 @@ mod lazy_item_set;
 mod lazy_item_vec;
 mod metric_distance;
 mod neighbour;
+mod new_struct;
 mod node;
 mod storage;
 mod vector;

--- a/src/models/serializer/new_struct.rs
+++ b/src/models/serializer/new_struct.rs
@@ -1,0 +1,88 @@
+use super::CustomSerialize;
+use crate::models::{
+    buffered_io::{BufIoError, BufferManagerFactory},
+    cache_loader::{Cacheable, NodeRegistry},
+    lazy_load::{FileIndex, LazyItem, NewStruct, SyncPersist, CHUNK_SIZE},
+    types::FileOffset,
+    versioning::Hash,
+};
+use std::collections::HashSet;
+use std::{io::SeekFrom, sync::Arc};
+
+impl CustomSerialize for NewStruct {
+    fn serialize(
+        &self,
+        bufmans: Arc<BufferManagerFactory>,
+        version: Hash,
+        cursor: u64,
+    ) -> Result<u32, BufIoError> {
+        let bufman = bufmans.get(&version)?;
+        let start_offset = bufman.cursor_position(cursor)? as u32;
+        let mut items = self.items.clone();
+        let total_items = items.len();
+
+        // Serialize number of items in the vector
+        // Each item is an array of 64 u32s
+        bufman.write_u32_with_cursor(cursor, total_items as u32)?;
+
+        // Serialize individual items
+        for (item, serialized) in items.iter() {
+            let item_start_offset = bufman.cursor_position(cursor)? as u32;
+            if *serialized {
+                // If the array is already serialized, move the cursor forward by 64 * 4 bytes and serialize the next array
+                bufman
+                    .seek_with_cursor(cursor, SeekFrom::Start(item_start_offset as u64 + 64 * 4))?;
+                continue;
+            }
+
+            // Serialize the array, storing u32::MAX for None values
+            for i in 0..64 {
+                bufman.write_u32_with_cursor(
+                    cursor,
+                    match item[i] {
+                        Some(val) => val,
+                        None => u32::MAX,
+                    },
+                )?;
+            }
+        }
+
+        Ok(start_offset)
+    }
+
+    fn deserialize(
+        bufmans: Arc<BufferManagerFactory>,
+        file_index: FileIndex,
+        cache: Arc<NodeRegistry>,
+        max_loads: u16,
+        skipm: &mut HashSet<u64>,
+    ) -> Result<Self, BufIoError> {
+        match file_index {
+            FileIndex::Invalid => Ok(NewStruct::new()),
+            FileIndex::Valid {
+                offset: FileOffset(offset),
+                version,
+            } => {
+                let bufman = bufmans.get(&version)?;
+                let cursor = bufman.open_cursor()?;
+                bufman.seek_with_cursor(cursor, SeekFrom::Start(offset as u64))?;
+                let mut items = Vec::new();
+
+                // Deserialize the number of items in the vector
+                let total_items = bufman.read_u32_with_cursor(cursor)? as usize;
+
+                // Deserialize individual items
+                for _ in 0..total_items {
+                    let mut item = [None; 64];
+                    for i in 0..64 {
+                        let val = bufman.read_u32_with_cursor(cursor)?;
+                        item[i] = if val == u32::MAX { None } else { Some(val) };
+                    }
+                    items.push((Box::new(item), true));
+                }
+
+                Ok(NewStruct { items })
+            }
+        }
+    }
+}


### PR DESCRIPTION
Create an incrementally serializable, growable collection.
The collection must support `apppend()` and `read_all()` and must be serializable incrementally.