### PR TITLE
fix(api_service/init_vector_store): prevent panic

### DIFF
--- a/src/api_service.rs
+++ b/src/api_service.rs
@@ -106,7 +106,12 @@ pub async fn init_vector_store(
         let lazy_node = LazyItem::from_arc(hash, 0, current_node.clone());
         let nn = LazyItemRef::from_arc(hash, 0, current_node.clone());
 
-        if let Some(prev_node) = prev.item.get().get_lazy_data().unwrap().get() {
+        if let Some(prev_node) = prev
+            .item
+            .get()
+            .get_lazy_data()
+            .and_then(|mut arc| arc.get().clone())
+        {
             current_node.set_parent(prev.clone().item.get().clone());
             prev_node.set_child(lazy_node.clone());
         }


### PR DESCRIPTION
don't panic when `prev` node is `Invalid`