### PR TITLE
chore(ci): add cargo fmt check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,27 @@ jobs:
           save-cache: ${{ github.ref_name == 'main' }}
           cache-key: warm
       - run: cargo test
+
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: taiki-e/checkout-action@v1
+      - uses: Boshen/setup-rust@main
+        with:
+          components: rustfmt
+          save-cache: ${{ github.ref_name == 'main' }}
+          cache-key: warm
+      - id: fmt
+        run: cargo fmt --all -- --check src/ benches/
+        continue-on-error: true
+      - if: steps.fmt.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.setFailed(`
+            Formatting check failed!
+
+            Please run this command before committing:
+            cargo fmt --all -- src/ benches/
+            `)


### PR DESCRIPTION
- Add new `format` job to CI workflow
- Check formatting in `src/` and `benches`/ directories by running `cargo fmt --all -- --check src/ benches/`
- Provide error message if formatting check fails: 
```
Formatting check failed!

Please run this command before committing:
cargo fmt --all -- src/ benches/
```