### PR TITLE
Optimize largest power of 4 computation

### DIFF
--- a/src/indexes/helpers.rs
+++ b/src/indexes/helpers.rs
@@ -1,10 +1,21 @@
+// pre-compute powers of 4
+const POWERS_OF_4: [u32; 16] = [
+    1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864,
+    268435456, 1073741824,
+];
 pub(crate) fn generate_power_of_4_list(valx: u32) -> Vec<(u32, u32)> {
     fn largest_power_of_4_exponent(n: u32) -> u32 {
-        let mut exponent = 0;
-        while (4u32.pow(exponent + 1)) <= n {
-            exponent += 1;
+        // binary search to get the exponent
+        match POWERS_OF_4.binary_search_by(|&x| x.cmp(&n)) {
+            Ok(index) => index as u32,
+            Err(index) => {
+                if index == 0 {
+                    0
+                } else {
+                    (index - 1) as u32
+                }
+            }
         }
-        exponent
     }
 
     let mut result = Vec::new();


### PR DESCRIPTION
Before it was taking `O(logn)` time to get the exponent of 4 less than equal to the value
As we know the the value cannot exceed `u32`, we can pre-compute the powers of 4 in which the index  of the pre-computed array will be the exponents..
So, as the size of the pre-computed array is fixed, the time complexity is reduced to `O(1)`.