### PR TITLE
Remove unused cbor crate from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ async-std = "1.12.0"
 bincode = "1.3.3"
 bs58 = "0.5.1"
 byteorder = "1.5.0"
-cbor = "0.4.1"
 chrono = { version = "0.4.38", features = ["serde"] }
 dashmap = "5.5.3"
 env_logger = "0.11.3"


### PR DESCRIPTION
Removes the unused `cbor` crate from `Cargo.toml`. It is not used anywhere in the codebase and was causing compatibility warnings.

After removing this dependency, I noticed that `serde_cbor` is being actively used for CBOR serialization/deserialization. Also, serde_cbor's GitHub page recommends moving to the `coborium` crate. Should we create a new issue to track a potential migration?