### PR TITLE
fix(quantization/scalar): compute sqrt at the time of quantization

### DIFF
--- a/src/distance/cosine.rs
+++ b/src/distance/cosine.rs
@@ -38,9 +38,7 @@ impl DistanceFunction for CosineSimilarity {
                 },
             ) => {
                 let dot_product = dot_product_u8(x_vec, y_vec) as f32;
-                let x_mag = (*x_mag as f32).sqrt();
-                let y_mag = (*y_mag as f32).sqrt();
-                cosine_similarity_from_dot_product(dot_product, x_mag, y_mag)
+                cosine_similarity_from_dot_product(dot_product, *x_mag, *y_mag)
             }
             (
                 Storage::SubByte {

--- a/src/models/serializer/hnsw/tests.rs
+++ b/src/models/serializer/hnsw/tests.rs
@@ -139,7 +139,7 @@ fn get_cache(
 fn create_prob_node(id: u64, prop_file: &RwLock<File>) -> ProbNode {
     let id = VectorId(id);
     let value = Arc::new(Storage::UnsignedByte {
-        mag: 10,
+        mag: 10.0,
         quant_vec: vec![1, 2, 3],
     });
     let mut prop_file_guard = prop_file.write().unwrap();

--- a/src/models/serializer/storage.rs
+++ b/src/models/serializer/storage.rs
@@ -19,7 +19,7 @@ impl SimpleSerialize for Storage {
         match self {
             Self::UnsignedByte { mag, quant_vec } => {
                 bufman.update_u8_with_cursor(cursor, 0)?;
-                bufman.update_u32_with_cursor(cursor, *mag)?;
+                bufman.update_f32_with_cursor(cursor, *mag)?;
                 bufman.update_u32_with_cursor(cursor, quant_vec.len() as u32)?;
                 for el in quant_vec {
                     bufman.update_u8_with_cursor(cursor, *el)?;
@@ -75,7 +75,7 @@ impl SimpleSerialize for Storage {
 
         let storage = match variant_index {
             0 => {
-                let mag = bufman.read_u32_with_cursor(cursor)?;
+                let mag = bufman.read_f32_with_cursor(cursor)?;
                 let len = bufman.read_u32_with_cursor(cursor)? as usize;
                 let mut quant_vec = Vec::with_capacity(len);
 

--- a/src/models/serializer/tests.rs
+++ b/src/models/serializer/tests.rs
@@ -10,7 +10,7 @@ use tempfile::TempDir;
 fn test_storage_serialization() {
     let storages = [
         Storage::UnsignedByte {
-            mag: 10,
+            mag: 10.0,
             quant_vec: vec![0, 1, 4],
         },
         Storage::SubByte {

--- a/src/quantization/scalar.rs
+++ b/src/quantization/scalar.rs
@@ -22,7 +22,8 @@ impl Quantization for ScalarQuantization {
                             as u8
                     })
                     .collect();
-                let mag = quant_vec.iter().map(|&x| x as u32 * x as u32).sum();
+                let mag =
+                    (quant_vec.iter().map(|&x| x as u32 * x as u32).sum::<u32>() as f32).sqrt();
                 Ok(Storage::UnsignedByte { mag, quant_vec })
             }
             StorageType::SubByte(resolution) => {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 )]
 pub enum Storage {
     UnsignedByte {
-        mag: u32,
+        mag: f32,
         quant_vec: Vec<u8>,
     },
     SubByte {


### PR DESCRIPTION
compute square root at the time of quantization instead of distance calculation for `UnsignedByte`