### PR TITLE
Metadata filtering fixes 2

### DIFF
--- a/src/api/vectordb/vectors/controller.rs
+++ b/src/api/vectordb/vectors/controller.rs
@@ -7,7 +7,6 @@ use super::{
     service,
 };
 
-use crate::models::collection_cache::CollectionCacheExt;
 use crate::{
     api_service::run_upload_dense_vectors,
     app_context::AppContext,
@@ -17,6 +16,7 @@ use crate::{
         types::VectorId,
     },
 };
+use crate::{indexes::hnsw::types::DenseInputVector, models::collection_cache::CollectionCacheExt};
 pub(crate) async fn create_vector(
     collection_id: web::Path<String>,
     web::Json(create_vector_dto): web::Json<CreateVectorDto>,
@@ -95,10 +95,10 @@ pub(crate) async fn upsert_vectors(
         )));
     }
 
-    let vecs_to_upload: Vec<(VectorId, Vec<f32>, Option<crate::metadata::MetadataFields>)> = body
+    let vecs_to_upload = body
         .vectors
         .into_iter()
-        .map(|dense_vec| (dense_vec.id, dense_vec.values, dense_vec.metadata))
+        .map(|dense_vec| DenseInputVector::new(dense_vec.id, dense_vec.values, dense_vec.metadata))
         .collect();
 
     run_upload_dense_vectors(ctx.into_inner(), hnsw_index.clone(), vecs_to_upload)

--- a/src/api/vectordb/vectors/repo.rs
+++ b/src/api/vectordb/vectors/repo.rs
@@ -9,7 +9,7 @@ use crate::{
         run_upload_tf_idf_documents_in_transaction,
     },
     indexes::{
-        hnsw::{transaction::HNSWIndexTransaction, HNSWIndex},
+        hnsw::{transaction::HNSWIndexTransaction, types::DenseInputVector, HNSWIndex},
         inverted::{transaction::InvertedIndexTransaction, InvertedIndex},
         tf_idf::{transaction::TFIDFIndexTransaction, TFIDFIndex},
     },
@@ -125,16 +125,13 @@ pub(crate) async fn create_dense_vector(
         ));
     }
 
-    run_upload_dense_vectors(
-        ctx,
-        hnsw_index,
-        vec![(
-            create_vector_dto.id.clone(),
-            create_vector_dto.values.clone(),
-            create_vector_dto.metadata.clone(),
-        )],
-    )
-    .map_err(VectorsError::WaCustom)?;
+    let input_vec = DenseInputVector::new(
+        create_vector_dto.id.clone(),
+        create_vector_dto.values.clone(),
+        create_vector_dto.metadata.clone(),
+    );
+
+    run_upload_dense_vectors(ctx, hnsw_index, vec![input_vec]).map_err(VectorsError::WaCustom)?;
 
     Ok(CreateVectorResponseDto::Dense(CreateDenseVectorDto {
         id: create_vector_dto.id,
@@ -222,12 +219,10 @@ pub(crate) async fn update_vector(
         )));
     }
 
-    run_upload_dense_vectors(
-        ctx,
-        hnsw_index,
-        vec![(vector_id.clone(), update_vector_dto.values.clone(), None)],
-    )
-    .map_err(VectorsError::WaCustom)?;
+    let input_vec =
+        DenseInputVector::new(vector_id.clone(), update_vector_dto.values.clone(), None);
+
+    run_upload_dense_vectors(ctx, hnsw_index, vec![input_vec]).map_err(VectorsError::WaCustom)?;
 
     Ok(UpdateVectorResponseDto {
         id: vector_id,

--- a/src/api_service.rs
+++ b/src/api_service.rs
@@ -128,7 +128,7 @@ pub async fn init_hnsw_index_for_collection(
     let factor_levels = 4.0;
 
     // If metadata schema is supported, the level_probs needs to be
-    // adjusted to accomodate only pseudo nodes in the higher layers
+    // adjusted to accommodate only pseudo nodes in the higher layers
     let lp = match &collection.metadata_schema {
         Some(metadata_schema) => {
             // @TODO(vineet): Unnecessary computation of
@@ -181,7 +181,7 @@ pub async fn init_hnsw_index_for_collection(
     // are reachable from the root node.
     if collection.metadata_schema.is_some() {
         let num_dims = collection.dense_vector.dimension;
-        let pseudo_vals: Vec<f32> = vec![0.0; num_dims];
+        let pseudo_vals: Vec<f32> = vec![1.0; num_dims];
         // The pseudo vector's id will be equal to the max number that
         // can be represented with 56 bits. This is because of how we
         // are calculating the combined id for nodes having metadata

--- a/src/api_service.rs
+++ b/src/api_service.rs
@@ -117,6 +117,7 @@ pub async fn init_hnsw_index_for_collection(
         values_range,
         &hnsw_params,
         *distance_metric.read().unwrap(),
+        collection.metadata_schema.as_ref(),
     )?;
 
     index_manager.flush_all()?;

--- a/src/api_service.rs
+++ b/src/api_service.rs
@@ -151,8 +151,6 @@ pub async fn init_hnsw_index_for_collection(
         None => generate_level_probs(factor_levels, hnsw_params.num_layers),
     };
 
-    println!("----- lp = {lp:?}; num_layers = {}", hnsw_params.num_layers);
-
     let hnsw_index = Arc::new(HNSWIndex::new(
         collection_name.clone(),
         root,

--- a/src/api_service.rs
+++ b/src/api_service.rs
@@ -10,7 +10,7 @@ use crate::indexes::inverted::InvertedIndex;
 use crate::indexes::tf_idf::{count_tokens, transaction::TFIDFIndexTransaction, TFIDFIndex};
 use crate::macros::key;
 use crate::metadata::query_filtering::filter_encoded_dimensions;
-use crate::metadata::{self, MetadataFields};
+use crate::metadata::{self, pseudo_level_probs, MetadataFields};
 use crate::models::buffered_io::BufferManagerFactory;
 use crate::models::cache_loader::HNSWIndexCache;
 use crate::models::collection::Collection;
@@ -125,7 +125,32 @@ pub async fn init_hnsw_index_for_collection(
     // -- TODO level entry ratio
     // ---------------------------
     let factor_levels = 4.0;
-    let lp = generate_level_probs(factor_levels, hnsw_params.num_layers);
+
+    // If metadata schema is supported, the level_probs needs to be
+    // adjusted to accomodate only pseudo nodes in the higher layers
+    let lp = match &collection.metadata_schema {
+        Some(metadata_schema) => {
+            // @TODO(vineet): Unnecessary computation of
+            // pseudo_weighted_dimensions. Just the no. of pseudo
+            // replicas should be sufficient.
+            let replica_dims = metadata_schema.pseudo_weighted_dimensions(1);
+            let plp = pseudo_level_probs(hnsw_params.num_layers, replica_dims.len() as u16);
+            // @TODO(vineet): Super hacky
+            let num_lower_layers = plp.iter().filter(|(p, _)| *p == 0.0).count() - 1;
+            let num_higher_layers = hnsw_params.num_layers - (num_lower_layers as u8);
+            let mut lp = vec![];
+            for i in 0..num_higher_layers {
+                // no actual replica nodes in higher layers
+                lp.push((1.0, hnsw_params.num_layers - i))
+            }
+            let mut lower_lp = generate_level_probs(factor_levels, num_lower_layers as u8);
+            lp.append(&mut lower_lp);
+            lp
+        }
+        None => generate_level_probs(factor_levels, hnsw_params.num_layers),
+    };
+
+    println!("----- lp = {lp:?}; num_layers = {}", hnsw_params.num_layers);
 
     let hnsw_index = Arc::new(HNSWIndex::new(
         collection_name.clone(),
@@ -149,6 +174,22 @@ pub async fn init_hnsw_index_for_collection(
     ctx.ain_env
         .collections_map
         .insert_hnsw_index(collection_name, hnsw_index.clone())?;
+
+    // If the collection has metadata schema, we create pseudo replica
+    // nodes to ensure that the query vectors with metadata dimensions
+    // are reachable from the root node.
+    if collection.metadata_schema.is_some() {
+        let num_dims = collection.dense_vector.dimension;
+        let pseudo_vals: Vec<f32> = vec![0.0; num_dims];
+        // The pseudo vector's id will be equal to the max number that
+        // can be represented with 56 bits. This is because of how we
+        // are calculating the combined id for nodes having metadata
+        // dims. See `ProbNode.get_id` implementation. Perhaps it'd be
+        // a good idea to derive this value from root.
+        let pseudo_vec_id = VectorId(u64::pow(2, 56) - 1);
+        let pseudo_vec = DenseInputVector::pseudo(pseudo_vec_id, pseudo_vals, None);
+        run_upload_dense_vectors(ctx, hnsw_index.clone(), vec![pseudo_vec])?;
+    }
 
     Ok(hnsw_index)
 }
@@ -825,6 +866,8 @@ pub fn run_upload_dense_vectors(
 
     let bufman = hnsw_index.vec_raw_manager.get(current_version)?;
 
+    let index_immediately = vecs[0].is_pseudo;
+
     // Insert vectors
     let vec_embs = vecs
         .into_par_iter()
@@ -869,7 +912,7 @@ pub fn run_upload_dense_vectors(
     }
 
     // Indexing happens while the LMDB lock is held, making sure the vectors are not double indexed
-    if new_count_unindexed >= ctx.config.upload_threshold {
+    if index_immediately || new_count_unindexed >= ctx.config.upload_threshold {
         let last_indexed_version_key = key!(m:last_indexed_version);
         let last_indexed_version = match txn.get(*db, &last_indexed_version_key) {
             Ok(bytes) => {
@@ -880,6 +923,7 @@ pub fn run_upload_dense_vectors(
             }
             Err(lmdb::Error::NotFound) => Ok(None),
             Err(e) => {
+                // @TODO(vineet): Fix key in log message
                 log::error!("Error reading 'count_unindexed' from metadata in lmdb");
                 Err(WaCustomError::DatabaseError(e.to_string()))
             }

--- a/src/distance/cosine.rs
+++ b/src/distance/cosine.rs
@@ -7,7 +7,7 @@ use crate::{
             dot_product_binary, dot_product_f16, dot_product_f32, dot_product_octal,
             dot_product_quaternary, dot_product_u8,
         },
-        types::VectorData,
+        types::{Metadata, ReplicaNodeKind, VectorData},
     },
     storage::Storage,
 };
@@ -37,192 +37,205 @@ impl DistanceFunction for CosineSimilarity {
         &self,
         x: &VectorData,
         y: &VectorData,
-        is_indexing: bool,
+        // @TODO(vineet): Check if is_index can be removed now
+        _is_indexing: bool,
     ) -> Result<Self::Item, DistanceError> {
-        // Here we're adding metadata fields for both vectors into a
-        // single tuple inside an Option that serves two purposes -
-        // 1. makes it easy to test if both vectors contain metadata
-        //    multiple times
-        // 2. allows dot product to be computed only once
-        let metadata = match (x.metadata, y.metadata) {
-            (Some(x_metadata), Some(y_metadata)) => {
-                // @TODO(vineet): Check if the second case (x) is
-                // required. Can we assume that x is always either the
-                // query vector (in case of is_indexing = false) and
-                // vector to be inserted (in case of is_indexing =
-                // true)?
-                if y_metadata.mag == 0.0 || x_metadata.mag == 0.0 {
-                    if is_indexing {
-                        // When indexing, if the vector to be inserted
-                        // has metadata fields but other node
-                        // (existing) it's compared with is a base
-                        // replica (i.e. having base dimensions
-                        // resulting in mag = 0), then we fallback to
-                        // comparing the combined vector + metadata
-                        // dimensions.
-                        None
-                    } else {
-                        // When querying, if the query vector has
-                        // metadata fields but the existing node it's
-                        // compared against is a base replica, then we
-                        // directly know it's a mismatch. Hence return
-                        // early.
-                        return Ok(CosineSimilarity(0.0));
-                    }
+        let x_kind = x.replica_node_kind();
+        let y_kind = y.replica_node_kind();
+        let sim = match (y_kind, x_kind) {
+            (ReplicaNodeKind::Pseudo, ReplicaNodeKind::Pseudo) => {
+                let x_metadata = x.metadata.unwrap();
+                let y_metadata = y.metadata.unwrap();
+                if x_metadata.mbits == y_metadata.mbits {
+                    CosineSimilarity(1.0)
                 } else {
-                    // @NOTE: Here we are casting i32 to f32, which means
-                    // truncation is possible, but it's not a concern in
-                    // this case because metadata dims will either be 0,
-                    // -1, 1 (query filter encoding) or high weight values
-                    // (we need to make sure it's high enough to be
-                    // effective but wouldn't result in truncation if
-                    // casted to f32)
-                    let x_mdims = x_metadata
-                        .mbits
-                        .iter()
-                        .map(|i| *i as f32)
-                        .collect::<Vec<f32>>();
-                    let y_mdims = y_metadata
-                        .mbits
-                        .iter()
-                        .map(|i| *i as f32)
-                        .collect::<Vec<f32>>();
-                    let m_dot_product: f32 = dot_product_f32(&x_mdims, &y_mdims);
-                    Some((x_metadata.mag, y_metadata.mag, m_dot_product))
+                    CosineSimilarity(0.0)
                 }
             }
-            _ => None,
+            (ReplicaNodeKind::Pseudo, ReplicaNodeKind::Base) => {
+                // A base node should never match an existing pseudo
+                // node
+                CosineSimilarity(0.0)
+            }
+            (ReplicaNodeKind::Pseudo, ReplicaNodeKind::Metadata) => {
+                let x_metadata = x.metadata.unwrap();
+                let y_metadata = y.metadata.unwrap();
+                if x_metadata.mbits == y_metadata.mbits {
+                    CosineSimilarity(1.0)
+                } else {
+                    CosineSimilarity(0.0)
+                }
+            }
+            (ReplicaNodeKind::Base, ReplicaNodeKind::Pseudo) => {
+                if y.is_pseudo_root() {
+                    CosineSimilarity(1.0)
+                } else {
+                    CosineSimilarity(-1.0)
+                }
+            }
+            (ReplicaNodeKind::Base, ReplicaNodeKind::Base) => {
+                cosine_similarity(x.quantized_vec, y.quantized_vec, None)?
+            }
+            (ReplicaNodeKind::Metadata, ReplicaNodeKind::Metadata) => {
+                let x_metadata = x.metadata.unwrap();
+                let y_metadata = y.metadata.unwrap();
+                if x_metadata.mbits == y_metadata.mbits {
+                    cosine_similarity(x.quantized_vec, y.quantized_vec, None)?
+                } else {
+                    CosineSimilarity(0.0)
+                }
+            }
+            (ReplicaNodeKind::Base, ReplicaNodeKind::Metadata) => CosineSimilarity(0.0),
+            (ReplicaNodeKind::Metadata, ReplicaNodeKind::Pseudo) => {
+                // This case is not possible
+                unreachable!()
+            }
+            (ReplicaNodeKind::Metadata, ReplicaNodeKind::Base) => {
+                // @TODO(vineet): This case is actually shouldn't be
+                // possible. Check why it's happening.
+                CosineSimilarity(0.0)
+            }
         };
+        Ok(sim)
+    }
+}
 
-        // If not indexing (which means we're querying), we match
-        // metadata dimensions on priority and short circuit if
-        // there's no match
-        if !is_indexing {
-            // If metadata exists in both vectors, we first compute cosine
-            // similarity for metadata dimensions. Only if the metadata
-            // similarity is ~1 (consider a small epsilon for floating
-            // point rounding), compute full similarity.
-            if let Some((x_mag, y_mag, m_dot_product)) = &metadata {
-                let m_cos_sim = cosine_similarity_from_dot_product(*m_dot_product, *x_mag, *y_mag)?;
-                let threshold: f32 = 0.99;
-                if m_cos_sim.0 < threshold {
-                    // Not close enough to 1, so return
-                    // CosineSimilarity of 0 as we don't want the
-                    // vectors to match
-                    return Ok(CosineSimilarity(0.0));
-                }
+// @NOTE: Following function is not in use. It's kept for later
+// reference if required.
+#[allow(unused)]
+fn metadata_dims_dot_product(
+    x_metadata: &Metadata,
+    y_metadata: &Metadata,
+) -> Option<(f32, f32, f32)> {
+    if x_metadata.mag == 0.0 || y_metadata.mag == 0.0 {
+        None
+    } else {
+        let x_mdims = x_metadata
+            .mbits
+            .iter()
+            .map(|i| *i as f32)
+            .collect::<Vec<f32>>();
+        let y_mdims = y_metadata
+            .mbits
+            .iter()
+            .map(|i| *i as f32)
+            .collect::<Vec<f32>>();
+        let m_dot_product: f32 = dot_product_f32(&x_mdims, &y_mdims);
+        Some((x_metadata.mag, y_metadata.mag, m_dot_product))
+    }
+}
+
+fn cosine_similarity(
+    x_quantized: &Storage,
+    y_quantized: &Storage,
+    m_dot_product: Option<(f32, f32, f32)>,
+) -> Result<CosineSimilarity, DistanceError> {
+    match (x_quantized, y_quantized) {
+        (
+            Storage::UnsignedByte {
+                mag: x_mag,
+                quant_vec: x_vec,
+            },
+            Storage::UnsignedByte {
+                mag: y_mag,
+                quant_vec: y_vec,
+            },
+        ) => {
+            let dot_product = dot_product_u8(x_vec, y_vec) as f32;
+            match &m_dot_product {
+                Some((x_mmag, y_mmag, m_dot_product)) => cosine_similarity_with_metadata(
+                    dot_product,
+                    *m_dot_product,
+                    *x_mag,
+                    *x_mmag,
+                    *y_mag,
+                    *y_mmag,
+                ),
+                _ => cosine_similarity_from_dot_product(dot_product, *x_mag, *y_mag),
             }
         }
-
-        // Only if metadata vectors are close enough, we compute total
-        // cosine similarity
-        match (x.quantized_vec, y.quantized_vec) {
-            (
-                Storage::UnsignedByte {
-                    mag: x_mag,
-                    quant_vec: x_vec,
-                },
-                Storage::UnsignedByte {
-                    mag: y_mag,
-                    quant_vec: y_vec,
-                },
-            ) => {
-                let dot_product = dot_product_u8(x_vec, y_vec) as f32;
-                match &metadata {
-                    Some((x_mmag, y_mmag, m_dot_product)) => cosine_similarity_with_metadata(
-                        dot_product,
-                        *m_dot_product,
-                        *x_mag,
-                        *x_mmag,
-                        *y_mag,
-                        *y_mmag,
-                    ),
-                    _ => cosine_similarity_from_dot_product(dot_product, *x_mag, *y_mag),
-                }
+        (
+            Storage::SubByte {
+                mag: x_mag,
+                quant_vec: x_vec,
+                resolution: x_res,
+            },
+            Storage::SubByte {
+                mag: y_mag,
+                quant_vec: y_vec,
+                resolution: y_res,
+            },
+        ) => {
+            if x_res != y_res {
+                return Err(DistanceError::StorageMismatch);
             }
-            (
-                Storage::SubByte {
-                    mag: x_mag,
-                    quant_vec: x_vec,
-                    resolution: x_res,
-                },
-                Storage::SubByte {
-                    mag: y_mag,
-                    quant_vec: y_vec,
-                    resolution: y_res,
-                },
-            ) => {
-                if x_res != y_res {
-                    return Err(DistanceError::StorageMismatch);
+            let dot_product = match *x_res {
+                1 => dot_product_binary(x_vec, y_vec, *x_res),
+                2 => dot_product_quaternary(x_vec, y_vec, *x_res),
+                3 => dot_product_octal(x_vec, y_vec, *x_res),
+                _ => {
+                    return Err(DistanceError::CalculationError);
                 }
-                let dot_product = match *x_res {
-                    1 => dot_product_binary(x_vec, y_vec, *x_res),
-                    2 => dot_product_quaternary(x_vec, y_vec, *x_res),
-                    3 => dot_product_octal(x_vec, y_vec, *x_res),
-                    _ => {
-                        return Err(DistanceError::CalculationError);
-                    }
-                };
-                match &metadata {
-                    Some((x_mmag, y_mmag, m_dot_product)) => cosine_similarity_with_metadata(
-                        dot_product,
-                        *m_dot_product,
-                        *x_mag,
-                        *x_mmag,
-                        *y_mag,
-                        *y_mmag,
-                    ),
-                    _ => cosine_similarity_from_dot_product(dot_product, *x_mag, *y_mag),
-                }
+            };
+            match &m_dot_product {
+                Some((x_mmag, y_mmag, m_dot_product)) => cosine_similarity_with_metadata(
+                    dot_product,
+                    *m_dot_product,
+                    *x_mag,
+                    *x_mmag,
+                    *y_mag,
+                    *y_mmag,
+                ),
+                _ => cosine_similarity_from_dot_product(dot_product, *x_mag, *y_mag),
             }
-            (
-                Storage::HalfPrecisionFP {
-                    mag: x_mag,
-                    quant_vec: x_vec,
-                },
-                Storage::HalfPrecisionFP {
-                    mag: y_mag,
-                    quant_vec: y_vec,
-                },
-            ) => {
-                let dot_product = dot_product_f16(x_vec, y_vec);
-                match &metadata {
-                    Some((x_mmag, y_mmag, m_dot_product)) => cosine_similarity_with_metadata(
-                        dot_product,
-                        *m_dot_product,
-                        *x_mag,
-                        *x_mmag,
-                        *y_mag,
-                        *y_mmag,
-                    ),
-                    _ => cosine_similarity_from_dot_product(dot_product, *x_mag, *y_mag),
-                }
-            }
-            (
-                Storage::FullPrecisionFP {
-                    mag: x_mag,
-                    vec: x_vec,
-                },
-                Storage::FullPrecisionFP {
-                    mag: y_mag,
-                    vec: y_vec,
-                },
-            ) => {
-                let dot_product = dot_product_f32(x_vec, y_vec);
-                match &metadata {
-                    Some((x_mmag, y_mmag, m_dot_product)) => cosine_similarity_with_metadata(
-                        dot_product,
-                        *m_dot_product,
-                        *x_mag,
-                        *x_mmag,
-                        *y_mag,
-                        *y_mmag,
-                    ),
-                    _ => cosine_similarity_from_dot_product(dot_product, *x_mag, *y_mag),
-                }
-            }
-            _ => Err(DistanceError::StorageMismatch),
         }
+        (
+            Storage::HalfPrecisionFP {
+                mag: x_mag,
+                quant_vec: x_vec,
+            },
+            Storage::HalfPrecisionFP {
+                mag: y_mag,
+                quant_vec: y_vec,
+            },
+        ) => {
+            let dot_product = dot_product_f16(x_vec, y_vec);
+            match &m_dot_product {
+                Some((x_mmag, y_mmag, m_dot_product)) => cosine_similarity_with_metadata(
+                    dot_product,
+                    *m_dot_product,
+                    *x_mag,
+                    *x_mmag,
+                    *y_mag,
+                    *y_mmag,
+                ),
+                _ => cosine_similarity_from_dot_product(dot_product, *x_mag, *y_mag),
+            }
+        }
+        (
+            Storage::FullPrecisionFP {
+                mag: x_mag,
+                vec: x_vec,
+            },
+            Storage::FullPrecisionFP {
+                mag: y_mag,
+                vec: y_vec,
+            },
+        ) => {
+            let dot_product = dot_product_f32(x_vec, y_vec);
+            match &m_dot_product {
+                Some((x_mmag, y_mmag, m_dot_product)) => cosine_similarity_with_metadata(
+                    dot_product,
+                    *m_dot_product,
+                    *x_mag,
+                    *x_mmag,
+                    *y_mag,
+                    *y_mmag,
+                ),
+                _ => cosine_similarity_from_dot_product(dot_product, *x_mag, *y_mag),
+            }
+        }
+        _ => Err(DistanceError::StorageMismatch),
     }
 }
 

--- a/src/distance/cosine.rs
+++ b/src/distance/cosine.rs
@@ -17,7 +17,12 @@ pub struct CosineDistance(pub f32);
 
 impl DistanceFunction for CosineDistance {
     type Item = Self;
-    fn calculate(&self, _x: &VectorData, _y: &VectorData, _is_indexing: bool) -> Result<Self::Item, DistanceError> {
+    fn calculate(
+        &self,
+        _x: &VectorData,
+        _y: &VectorData,
+        _is_indexing: bool,
+    ) -> Result<Self::Item, DistanceError> {
         // TODO: Implement cosine distance
         unimplemented!("Cosine distance is not implemented yet");
     }
@@ -28,7 +33,12 @@ pub struct CosineSimilarity(pub f32);
 
 impl DistanceFunction for CosineSimilarity {
     type Item = Self;
-    fn calculate(&self, x: &VectorData, y: &VectorData, is_indexing: bool) -> Result<Self::Item, DistanceError> {
+    fn calculate(
+        &self,
+        x: &VectorData,
+        y: &VectorData,
+        is_indexing: bool,
+    ) -> Result<Self::Item, DistanceError> {
         // Here we're adding metadata fields for both vectors into a
         // single tuple inside an Option that serves two purposes -
         // 1. makes it easy to test if both vectors contain metadata
@@ -92,18 +102,15 @@ impl DistanceFunction for CosineSimilarity {
             // similarity for metadata dimensions. Only if the metadata
             // similarity is ~1 (consider a small epsilon for floating
             // point rounding), compute full similarity.
-            match &metadata {
-                Some((x_mag, y_mag, m_dot_product)) => {
-                    let m_cos_sim = cosine_similarity_from_dot_product(*m_dot_product, *x_mag, *y_mag)?;
-                    let threshold: f32 = 0.99;
-                    if m_cos_sim.0 < threshold {
-                        // Not close enough to 1, so return
-                        // CosineSimilarity of 0 as we don't want the
-                        // vectors to match
-                        return Ok(CosineSimilarity(0.0));
-                    }
+            if let Some((x_mag, y_mag, m_dot_product)) = &metadata {
+                let m_cos_sim = cosine_similarity_from_dot_product(*m_dot_product, *x_mag, *y_mag)?;
+                let threshold: f32 = 0.99;
+                if m_cos_sim.0 < threshold {
+                    // Not close enough to 1, so return
+                    // CosineSimilarity of 0 as we don't want the
+                    // vectors to match
+                    return Ok(CosineSimilarity(0.0));
                 }
-                _ => { }
             }
         }
 

--- a/src/distance/dotproduct.rs
+++ b/src/distance/dotproduct.rs
@@ -11,7 +11,7 @@ pub struct DotProductDistance(pub f32);
 
 impl DistanceFunction for DotProductDistance {
     type Item = Self;
-    fn calculate(&self, x: &VectorData, y: &VectorData) -> Result<Self::Item, DistanceError> {
+    fn calculate(&self, x: &VectorData, y: &VectorData, _is_indexing: bool) -> Result<Self::Item, DistanceError> {
         match (x.quantized_vec, y.quantized_vec) {
             (
                 Storage::UnsignedByte {

--- a/src/distance/dotproduct.rs
+++ b/src/distance/dotproduct.rs
@@ -11,7 +11,12 @@ pub struct DotProductDistance(pub f32);
 
 impl DistanceFunction for DotProductDistance {
     type Item = Self;
-    fn calculate(&self, x: &VectorData, y: &VectorData, _is_indexing: bool) -> Result<Self::Item, DistanceError> {
+    fn calculate(
+        &self,
+        x: &VectorData,
+        y: &VectorData,
+        _is_indexing: bool,
+    ) -> Result<Self::Item, DistanceError> {
         match (x.quantized_vec, y.quantized_vec) {
             (
                 Storage::UnsignedByte {

--- a/src/distance/euclidean.rs
+++ b/src/distance/euclidean.rs
@@ -8,7 +8,7 @@ pub struct EuclideanDistance(pub f32);
 
 impl DistanceFunction for EuclideanDistance {
     type Item = Self;
-    fn calculate(&self, x: &VectorData, y: &VectorData) -> Result<Self::Item, DistanceError> {
+    fn calculate(&self, x: &VectorData, y: &VectorData, _is_indexing: bool) -> Result<Self::Item, DistanceError> {
         match (x.quantized_vec, y.quantized_vec) {
             (
                 Storage::UnsignedByte {

--- a/src/distance/euclidean.rs
+++ b/src/distance/euclidean.rs
@@ -8,7 +8,12 @@ pub struct EuclideanDistance(pub f32);
 
 impl DistanceFunction for EuclideanDistance {
     type Item = Self;
-    fn calculate(&self, x: &VectorData, y: &VectorData, _is_indexing: bool) -> Result<Self::Item, DistanceError> {
+    fn calculate(
+        &self,
+        x: &VectorData,
+        y: &VectorData,
+        _is_indexing: bool,
+    ) -> Result<Self::Item, DistanceError> {
         match (x.quantized_vec, y.quantized_vec) {
             (
                 Storage::UnsignedByte {

--- a/src/distance/hamming.rs
+++ b/src/distance/hamming.rs
@@ -11,7 +11,12 @@ impl DistanceFunction for HammingDistance {
 
     // Implementation here
     #[allow(unused_variables)]
-    fn calculate(&self, x: &VectorData, y: &VectorData, _is_indexing: bool) -> Result<Self::Item, DistanceError> {
+    fn calculate(
+        &self,
+        x: &VectorData,
+        y: &VectorData,
+        _is_indexing: bool,
+    ) -> Result<Self::Item, DistanceError> {
         match (x.quantized_vec, y.quantized_vec) {
             (
                 Storage::UnsignedByte {

--- a/src/distance/hamming.rs
+++ b/src/distance/hamming.rs
@@ -11,7 +11,7 @@ impl DistanceFunction for HammingDistance {
 
     // Implementation here
     #[allow(unused_variables)]
-    fn calculate(&self, x: &VectorData, y: &VectorData) -> Result<Self::Item, DistanceError> {
+    fn calculate(&self, x: &VectorData, y: &VectorData, _is_indexing: bool) -> Result<Self::Item, DistanceError> {
         match (x.quantized_vec, y.quantized_vec) {
             (
                 Storage::UnsignedByte {

--- a/src/distance/mod.rs
+++ b/src/distance/mod.rs
@@ -7,7 +7,12 @@ use crate::models::types::VectorData;
 
 pub trait DistanceFunction: std::fmt::Debug + Send + Sync {
     type Item;
-    fn calculate(&self, x: &VectorData, y: &VectorData, is_indexing: bool) -> Result<Self::Item, DistanceError>;
+    fn calculate(
+        &self,
+        x: &VectorData,
+        y: &VectorData,
+        is_indexing: bool,
+    ) -> Result<Self::Item, DistanceError>;
 }
 
 #[derive(Debug)]

--- a/src/distance/mod.rs
+++ b/src/distance/mod.rs
@@ -7,7 +7,7 @@ use crate::models::types::VectorData;
 
 pub trait DistanceFunction: std::fmt::Debug + Send + Sync {
     type Item;
-    fn calculate(&self, x: &VectorData, y: &VectorData) -> Result<Self::Item, DistanceError>;
+    fn calculate(&self, x: &VectorData, y: &VectorData, is_indexing: bool) -> Result<Self::Item, DistanceError>;
 }
 
 #[derive(Debug)]

--- a/src/grpc/vectors/mod.rs
+++ b/src/grpc/vectors/mod.rs
@@ -2,6 +2,7 @@
 // #[cfg(test)]
 // mod tests;
 
+use crate::indexes::hnsw::types::DenseInputVector;
 use crate::models::common::WaCustomError;
 use crate::models::types::VectorId;
 use crate::{app_context::AppContext, indexes::inverted::types::SparsePair};
@@ -46,7 +47,9 @@ impl VectorsService for VectorsServiceImpl {
 
                 // Prepare vector for insertion
                 // @TODO(vineet): Add support for optional metadata fields
-                let vec_to_insert = vec![(VectorId(dense.id), dense.values.clone(), None)];
+                let vec_to_insert = vec![
+                    DenseInputVector::new(VectorId(dense.id), dense.values.clone(), None)
+                ];
                 let hnsw_index = self.context.ain_env.collections_map
                     .get_hnsw_index(&req.collection_id)
                     .ok_or_else(|| Status::failed_precondition(
@@ -175,7 +178,9 @@ impl VectorsService for VectorsServiceImpl {
             .ok_or_else(|| Status::failed_precondition("Dense index not initialized"))?;
 
         // @TODO(vineet): Add support for optional metadata fields
-        let vec_to_update = vec![(VectorId(req.vector_id), req.values.clone(), None)];
+        let vec_to_update = vec![
+            DenseInputVector::new(VectorId(req.vector_id), req.values.clone(), None)
+        ];
         crate::api_service::run_upload_dense_vectors(
             self.context.clone(),
             hnsw_index.clone(),

--- a/src/indexes/hnsw/types.rs
+++ b/src/indexes/hnsw/types.rs
@@ -35,8 +35,7 @@ pub struct DenseInputVector {
     id: VectorId,
     vec: Vec<f32>,
     metadata_fields: Option<MetadataFields>,
-    #[allow(unused)]
-    is_pseudo: bool,
+    pub is_pseudo: bool,
 }
 
 impl DenseInputVector {
@@ -72,6 +71,7 @@ pub struct RawDenseVectorEmbedding {
     pub raw_vec: Arc<Vec<f32>>,
     pub hash_vec: VectorId,
     pub raw_metadata: Option<MetadataFields>,
+    pub is_pseudo: bool,
 }
 
 impl From<DenseInputVector> for RawDenseVectorEmbedding {
@@ -80,6 +80,7 @@ impl From<DenseInputVector> for RawDenseVectorEmbedding {
             raw_vec: Arc::new(source.vec),
             hash_vec: source.id,
             raw_metadata: source.metadata_fields,
+            is_pseudo: source.is_pseudo,
         }
     }
 }

--- a/src/indexes/hnsw/types.rs
+++ b/src/indexes/hnsw/types.rs
@@ -29,6 +29,36 @@ impl HNSWHyperParams {
     }
 }
 
+/// A representation of vector that can be passed as input to the
+/// functions that insert and index vectors in the collection
+pub struct DenseInputVector {
+    id: VectorId,
+    vec: Vec<f32>,
+    metadata_fields: Option<MetadataFields>,
+    #[allow(unused)]
+    is_pseudo: bool,
+}
+
+impl DenseInputVector {
+    pub fn new(id: VectorId, vec: Vec<f32>, metadata_fields: Option<MetadataFields>) -> Self {
+        Self {
+            id,
+            vec,
+            metadata_fields,
+            is_pseudo: false,
+        }
+    }
+
+    pub fn pseudo(id: VectorId, vec: Vec<f32>, metadata_fields: Option<MetadataFields>) -> Self {
+        Self {
+            id,
+            vec,
+            metadata_fields,
+            is_pseudo: true,
+        }
+    }
+}
+
 // Quantized vector embedding
 #[derive(Debug, Clone, PartialEq)]
 pub struct QuantizedDenseVectorEmbedding {
@@ -42,4 +72,14 @@ pub struct RawDenseVectorEmbedding {
     pub raw_vec: Arc<Vec<f32>>,
     pub hash_vec: VectorId,
     pub raw_metadata: Option<MetadataFields>,
+}
+
+impl From<DenseInputVector> for RawDenseVectorEmbedding {
+    fn from(source: DenseInputVector) -> Self {
+        Self {
+            raw_vec: Arc::new(source.vec),
+            hash_vec: source.id,
+            raw_metadata: source.metadata_fields,
+        }
+    }
 }

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -15,7 +15,7 @@ pub use schema::MetadataSchema;
 
 use crate::models::common::generate_level_probs;
 
-const HIGH_WEIGHT: i32 = 64000;
+pub const HIGH_WEIGHT: i32 = 1;
 
 #[derive(Debug, Clone)]
 pub enum Error {

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -136,8 +136,36 @@ pub fn fields_to_dimensions(
     Ok(result)
 }
 
+fn gen_combinations(vs: &Vec<Vec<u16>>) -> Vec<Vec<u16>> {
+    if vs.is_empty() {
+        return vec![];
+    }
+    // Start with a single empty combination
+    let mut combinations = vec![Vec::new()];
+    // For each vector in the input
+    for v in vs {
+        // Create new combinations by extending each existing combination
+        // with each element from the current vector
+        let mut new_combinations = Vec::new();
+        for combination in combinations {
+            for item in v {
+                // Create a new combination by cloning the existing
+                // one and adding the new item
+                let mut new_combination = combination.clone();
+                new_combination.push(*item);
+                new_combinations.push(new_combination);
+            }
+        }
+        // Replace the old combinations with the new ones
+        combinations = new_combinations;
+    }
+    combinations
+}
+
 #[cfg(test)]
 mod tests {
+
+    use std::collections::HashSet;
 
     use super::*;
 
@@ -155,5 +183,40 @@ mod tests {
     fn test_decimal_to_binary_vec() {
         assert_eq!(vec![0, 1, 1, 1], decimal_to_binary_vec(7, 4));
         assert_eq!(vec![0, 0, 1, 1], decimal_to_binary_vec(3, 4));
+    }
+
+    #[test]
+    fn test_gen_combinations() {
+        let vs = vec![vec![1, 2, 3], vec![4, 5]];
+        let cs = gen_combinations(&vs)
+            .into_iter()
+            .collect::<HashSet<Vec<u16>>>();
+        let expected: Vec<Vec<u16>> = vec![
+            vec![1, 4],
+            vec![1, 5],
+            vec![2, 4],
+            vec![2, 5],
+            vec![3, 4],
+            vec![3, 5],
+        ];
+        let e = expected.into_iter().collect::<HashSet<Vec<u16>>>();
+        assert_eq!(e, cs);
+
+        let vs = vec![vec![0], vec![1, 2], vec![4, 5]];
+        let cs = gen_combinations(&vs)
+            .into_iter()
+            .collect::<HashSet<Vec<u16>>>();
+        let expected: Vec<Vec<u16>> =
+            vec![vec![0, 1, 4], vec![0, 1, 5], vec![0, 2, 4], vec![0, 2, 5]];
+        let e = expected.into_iter().collect::<HashSet<Vec<u16>>>();
+        assert_eq!(e, cs);
+
+        let vs = vec![vec![0], vec![0], vec![4, 5]];
+        let cs = gen_combinations(&vs)
+            .into_iter()
+            .collect::<HashSet<Vec<u16>>>();
+        let expected: Vec<Vec<u16>> = vec![vec![0, 0, 4], vec![0, 0, 5]];
+        let e = expected.into_iter().collect::<HashSet<Vec<u16>>>();
+        assert_eq!(e, cs);
     }
 }

--- a/src/metadata/query_filtering.rs
+++ b/src/metadata/query_filtering.rs
@@ -34,7 +34,7 @@ fn query_filter_encoding(value_id: u16, size: usize, operator: &Operator) -> Que
                 if *x == 1 {
                     1
                 } else {
-                    -1
+                    0
                 }
             }
             Operator::NotEqual => {
@@ -74,7 +74,7 @@ fn and_predicates_to_dimensions(
                 result.append(&mut dims);
             }
             None => {
-                let mut dims = vec![-1; field.num_dims as usize];
+                let mut dims = vec![0; field.num_dims as usize];
                 result.append(&mut dims);
             }
         }
@@ -129,7 +129,7 @@ mod tests {
     fn test_query_filter_encoding() {
         // value 7 represented in 5 dimensions
         let e1 = query_filter_encoding(7, 5, &Operator::Equal);
-        assert_eq!(vec![-1, -1, 1, 1, 1], e1);
+        assert_eq!(vec![0, 0, 1, 1, 1], e1);
 
         let e2 = query_filter_encoding(7, 5, &Operator::NotEqual);
         assert_eq!(vec![1, 1, -1, -1, -1], e2);
@@ -159,8 +159,8 @@ mod tests {
         let qfed = filter_encoded_dimensions(&schema, &filter).unwrap();
         assert_eq!(
             vec![vec![
-                -1, 1, 1, -1, // 6 (original value: 6)
-                -1, -1
+                0, 1, 1, 0, // 6 (original value: 6)
+                0, 0
             ]],
             qfed
         );
@@ -181,7 +181,7 @@ mod tests {
         let qfed = filter_encoded_dimensions(&schema, &filter).unwrap();
         assert_eq!(
             vec![vec![
-                -1, -1, 1, -1, // 2 (original value: 2)
+                0, 0, 1, 0, // 2 (original value: 2)
                 -1, 1 // !2 (original value: !b)
             ]],
             qfed
@@ -204,11 +204,11 @@ mod tests {
         assert_eq!(
             vec![
                 vec![
-                    -1, -1, 1, -1, // 2 (original value: 2)
-                    -1, -1
+                    0, 0, 1, 0, // 2 (original value: 2)
+                    0, 0
                 ],
                 vec![
-                    -1, -1, -1, -1,
+                    0, 0, 0, 0,
                     -1, 1  // !2 (original value: !b)
                 ]
             ],

--- a/src/metadata/schema.rs
+++ b/src/metadata/schema.rs
@@ -1,9 +1,14 @@
 use serde::{Deserialize, Serialize};
 
+use crate::metadata::gen_combinations;
+
 use super::{
     decimal_to_binary_vec, nearest_power_of_two, Error, FieldName, FieldValue, MetadataFields,
 };
-use std::collections::{HashMap, HashSet};
+use std::{
+    cmp::Reverse,
+    collections::{HashMap, HashSet},
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SupportedCondition {
@@ -98,6 +103,10 @@ impl MetadataField {
                 value, self.name
             )))
     }
+
+    pub fn max_cardinality(&self) -> u8 {
+        2u8.pow(self.num_dims as u32) - 1
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -130,6 +139,10 @@ impl MetadataSchema {
         }
     }
 
+    pub fn num_total_dims(&self) -> u8 {
+        self.fields.iter().map(|field| field.num_dims).sum()
+    }
+
     /// Return base dimensions for the MetadataSchema instance
     ///
     /// Base dimensions are to be used when there are no metadata
@@ -140,7 +153,7 @@ impl MetadataSchema {
         //
         // @TODO(vineet): Perhaps we should put a limit on max no. of
         // metadata fields supported
-        let sum: u8 = self.fields.iter().map(|field| field.num_dims).sum();
+        let sum: u8 = self.num_total_dims();
         vec![0; sum as usize]
     }
 
@@ -272,6 +285,123 @@ impl MetadataSchema {
             result.push(dims);
         }
         Ok(result)
+    }
+
+    pub fn pseudo_weighted_dimensions(&self, weight: i32) -> Vec<MetadataDimensions> {
+        // A hashmap of field names to the value_ids in asc
+        // order. Will be constructed when iterting through the fields
+        // for the first time.
+        let mut field_value_ids: HashMap<String, Vec<u16>> =
+            HashMap::with_capacity(self.fields.len());
+
+        // We first find all combinations of field values ids i.e. if
+        // there are 2 fields `foo`: [1, 2] and `bar`: [3, 4], then
+        // combinations will be a vector of items such as [1, 3], [1,
+        // 4], [2, 3], [2, 4]. Note that the order of value_ids in the
+        // inner vectors matter (same as the order of `self.fields`).
+        let mut combinations: Vec<Vec<u16>> = vec![];
+
+        let num_fields = self.fields.len();
+
+        // Compute combinations for individual fields i.e. for every
+        // field, only that field has non-zero value and the remaining
+        // are all zero.
+        for x in &self.fields {
+            let c = x.max_cardinality();
+            let vids = (1..=c).map(|i| i as u16).collect::<Vec<u16>>();
+            field_value_ids.insert(x.name.clone(), vids.clone());
+
+            let mut vs = Vec::with_capacity(num_fields);
+            for y in &self.fields {
+                if x.name == y.name {
+                    vs.push(vids.clone());
+                } else {
+                    vs.push(vec![0]);
+                }
+            }
+            let mut cs = gen_combinations(&vs);
+            combinations.append(&mut cs);
+        }
+
+        let mut is_pseudo_root_created = self.fields.len() == 1 && self.conditions.is_empty();
+
+        // Compute combinations for supported `And` conditions
+        // i.e. only the fields that are part of a supported `And`
+        // condition will have non-zero values.
+        for condition in &self.conditions {
+            if let SupportedCondition::And(cond_fields) = condition {
+                let mut vs = Vec::with_capacity(num_fields);
+                for field in &self.fields {
+                    if cond_fields.contains(&field.name) {
+                        let vids = field_value_ids.get(&field.name).unwrap();
+                        vs.push(vids.clone());
+                    } else {
+                        vs.push(vec![0]);
+                    }
+                }
+                let mut cs = gen_combinations(&vs);
+                combinations.append(&mut cs);
+
+                // Check if the schema supports an `And` condition
+                // between all fields.
+                if cond_fields.len() == self.fields.len() {
+                    is_pseudo_root_created = true;
+                }
+            }
+        }
+
+        // Sort all combinations by the sum of the values. This is so
+        // that if the combination that has max value ids for every
+        // field exists, it ends up at the beginning of the vector
+        combinations.sort_by_cached_key(|c| Reverse(c.iter().copied().sum::<u16>()));
+
+        // Explicitly add combination for the max cardinality of each
+        // field. This is required only if `is_all_and_supported` is
+        // false. In other words, if `And` condition between all
+        // fields is supported, then this combination must have been
+        // already been added.
+        if !is_pseudo_root_created {
+            let mut combination = Vec::with_capacity(num_fields);
+            for field in &self.fields {
+                let vids = field_value_ids.get(&field.name).unwrap();
+                // @SAFETY: It's safe to use unwrap here as we know
+                // that `vids` won't be empty.
+                let max_val = *vids.as_slice().last().unwrap();
+                combination.push(max_val);
+            }
+            // Insert this combination at the beginning of the vector
+            combinations.insert(0, combination);
+        }
+
+        // Convert combinations of valid_ids into pseudo_dimensions
+        // (binary_vec with high weight values)
+        let mut pseudo_dimensions = Vec::with_capacity(combinations.len());
+        // We cache the results of calling fn `decimal_to_binary_vec`
+        // as there's a chance it would get called multiple times for
+        // the same input
+        let mut cache: HashMap<(u16, usize), Vec<i32>> = HashMap::new();
+
+        for combination in combinations {
+            let mut dims = Vec::with_capacity(num_fields);
+            for (i, value_id) in combination.iter().enumerate() {
+                let size = self.fields[i].num_dims as usize;
+                let mut field_dims = match cache.get(&(*value_id, size)) {
+                    Some(r) => r.clone(),
+                    None => {
+                        let r = decimal_to_binary_vec(*value_id, size)
+                            .iter()
+                            .map(|x| (*x as i32) * weight)
+                            .collect::<Vec<i32>>();
+                        cache.insert((*value_id, size), r.clone());
+                        r
+                    }
+                };
+                dims.append(&mut field_dims);
+            }
+            pseudo_dimensions.push(dims);
+        }
+
+        pseudo_dimensions
     }
 
     pub fn get_field(&self, name: &str) -> Result<&MetadataField, Error> {
@@ -759,5 +889,61 @@ mod tests {
         let orig: MetadataSchema = from_slice(&slice).unwrap();
 
         assert_eq!(schema.fields.len(), orig.fields.len());
+    }
+
+    #[test]
+    fn test_pseudo_weighted_dimensions() {
+        let age_values = (1..=2).map(FieldValue::Int).collect();
+        let age = MetadataField::new("age".to_owned(), age_values).unwrap();
+
+        let color_values: HashSet<FieldValue> = vec!["red", "yellow", "green"]
+            .into_iter()
+            .map(|x| FieldValue::String(String::from(x)))
+            .collect();
+        let color = MetadataField::new("color".to_owned(), color_values).unwrap();
+
+        let group_values: HashSet<FieldValue> = vec!["a", "b", "c", "d"]
+            .into_iter()
+            .map(|x| FieldValue::String(String::from(x)))
+            .collect();
+        let group = MetadataField::new("group".to_owned(), group_values).unwrap();
+
+        let conditions = vec![SupportedCondition::And(hashset(vec!["age", "color"]))];
+
+        let schema = MetadataSchema::new(vec![age, color, group], conditions).unwrap();
+
+        let pwd = schema.pseudo_weighted_dimensions(1024);
+
+        // Note that cardinality of age and color is 2 and 3
+        // respectively. But we're considering max_cardinality for the
+        // dimension size which happens to be 3 and 3. This is because
+        // the value 0 implicitly takes up one bit. So to represent 2
+        // age values, we need 3 bits and hence the max_cardinality is
+        // 3.
+        let exp_total = 23; // 13 (individual) + 9 (age x color) + 1 (all)
+        assert_eq!(exp_total, pwd.len());
+
+        let num_total_dims = schema.num_total_dims();
+        assert_eq!(7, num_total_dims);
+
+        // The max pseudo node is at the beginning of the returned
+        // vector
+        assert_eq!(vec![1024; num_total_dims as usize], pwd[0]);
+
+        // Test with only 1 field
+        let status_values: HashSet<FieldValue> = vec!["todo", "done"]
+            .into_iter()
+            .map(|x| FieldValue::String(String::from(x)))
+            .collect();
+        let status = MetadataField::new("status".to_owned(), status_values).unwrap();
+
+        let schema = MetadataSchema::new(vec![status], vec![]).unwrap();
+
+        let pwd = schema.pseudo_weighted_dimensions(1);
+
+        assert_eq!(3, pwd.len());
+        // [1, 1]
+        // [1, 0]
+        // [0, 1]
     }
 }

--- a/src/metadata/schema.rs
+++ b/src/metadata/schema.rs
@@ -160,11 +160,19 @@ impl MetadataSchema {
         if input_fields.is_empty() {
             return vec![];
         }
-        let input_fields_set = input_fields
-            .keys()
-            .map(|n| n.as_ref())
-            .collect::<HashSet<&str>>();
-        let mut combinations = HashSet::new();
+
+        let mut input_fields_set: HashSet<&str> = HashSet::new();
+        let mut combinations: HashSet<Vec<&str>> = HashSet::new();
+
+        // Create individual field combinations. This is an oxymoron
+        // but for the ease of deduplicating all combinations in a
+        // single place, we consider it as a combination that contains
+        // a single field.
+        for key in input_fields.keys() {
+            input_fields_set.insert(key.as_ref());
+            combinations.insert(vec![key.as_ref()]);
+        }
+
         for condition in &self.conditions {
             // @NOTE: We only consider `And` conditions, `Or` conditions
             // will be covered by the "all fields" combination, which will
@@ -235,32 +243,34 @@ impl MetadataSchema {
         fields: &HashMap<FieldName, FieldValue>,
         weight: i32,
     ) -> Result<Vec<MetadataDimensions>, Error> {
-        let field_combinations = self.input_field_combinations(fields);
-        let mut cache: HashMap<&str, Vec<i32>> = HashMap::new();
+        let field_combinations = self.input_field_combinations(&fields);
+        // We cache the results of calling fn `decimal_to_binary_vec`
+        // as there's a chance it would get called multiple times for
+        // the same input
+        let mut cache: HashMap<(u16, usize), Vec<i32>> = HashMap::new();
         let mut result = Vec::with_capacity(field_combinations.len());
         for field_combination in field_combinations {
             let mut dims = vec![];
             for field in &self.fields {
-                if let Some(v) = cache.get(&field.name.as_ref()) {
-                    let mut field_dims = v.clone();
-                    dims.append(&mut field_dims);
-                } else {
-                    let field_dims = match field_combination.get(&field.name.as_ref()) {
-                        Some(value) => {
-                            let value_id = field.value_id(value)?;
-                            decimal_to_binary_vec(value_id, field.num_dims as usize)
-                                .iter()
-                                .map(|x| (*x as i32) * weight)
-                                .collect::<Vec<i32>>()
+                let mut field_dims = match field_combination.get(&field.name.as_ref()) {
+                    Some(value) => {
+                        let value_id = field.value_id(&value)?;
+                        let size = field.num_dims as usize;
+                        match cache.get(&(value_id, size)) {
+                            Some(r) => r.clone(),
+                            None => {
+                                let dims = decimal_to_binary_vec(value_id, size)
+                                    .iter()
+                                    .map(|x| (*x as i32) * weight)
+                                    .collect::<Vec<i32>>();
+                                cache.insert((value_id, size), dims.clone());
+                                dims
+                            },
                         }
-                        None => {
-                            vec![0; field.num_dims as usize]
-                        }
-                    };
-                    let mut field_dims_clone = field_dims.clone();
-                    cache.insert(&field.name, field_dims);
-                    dims.append(&mut field_dims_clone);
-                }
+                    }
+                    None => vec![0; field.num_dims as usize],
+                };
+                dims.append(&mut field_dims);
             }
             result.push(dims);
         }
@@ -406,6 +416,27 @@ mod tests {
         }
     }
 
+    // Following fns that are prefixed with `ifc_` are test util for
+    // testing the fn `input_field_combinations`.
+
+    fn ifc_input(kvs: Vec<(&str, i32)>) -> MetadataFields {
+        kvs.into_iter()
+            .map(|(k, v)| (k.to_owned(), FieldValue::Int(v)))
+            .collect()
+    }
+
+    fn ifc_sort_result(result: &mut Vec<HashMap<&str, &FieldValue>>) {
+        result.sort_by_key(|c| {
+            c.values()
+                .map(|v| {
+                    match v {
+                        FieldValue::Int(i) => *i,
+                        FieldValue::String(_) => 0,
+                    }})
+                .sum::<i32>()
+        })
+    }
+
     #[test]
     fn test_input_field_combinations() {
         let a_values: HashSet<FieldValue> = (1..=10).map(FieldValue::Int).collect();
@@ -423,98 +454,112 @@ mod tests {
             SupportedCondition::Or(hashset(vec!["a", "b"])),
         ];
 
-        // Helper fn to create the MetadataFields hashmap from
-        // key-value tuples
-        let input_fields = |kvs: Vec<(&str, i32)>| {
-            kvs.into_iter()
-                .map(|(k, v)| (k.to_owned(), FieldValue::Int(v)))
-                .collect::<HashMap<String, FieldValue>>()
-        };
-
         let schema = MetadataSchema::new(vec![a, b, c], conditions).unwrap();
 
-        // As the input contains only a single field, only the
-        // following supported conditions are relevant to this vector:
+        // Test case 1: As the input contains only a single field,
+        // only the following replicas are relevant to this vector:
         //
         //  1. matches "a"
         //
         // Hence the result is 1 combination i.e. 1 replica
-        let fs = input_fields(vec![("a", 1)]);
+        let fs = ifc_input(vec![("a", 1)]);
         let cs = schema.input_field_combinations(&fs);
         assert_eq!(1, cs.len());
         let mut ec1 = HashMap::with_capacity(1);
         ec1.insert("a", &FieldValue::Int(1));
         assert_eq!(ec1, cs[0]);
 
-        // As the input contains only "a" and "b", only the following
-        // supported `AND` conditions are relevant to this vector
+        // Test case 2: As the input contains only "a" and "b", only
+        // the following replicas are relevant to this vector
         //
-        //   1. matches "a and b"
+        //   1. matches "a"
+        //   2. matches "b"
+        //   3. matches "a AND b"
         //
-        // Hence the result is 1 combination i.e. 1 replica. It is
-        // sufficient and it's also equivalent to the "all fields"
-        // replica to support individual field matches and OR
-        // conditions.
-        let fs = input_fields(vec![("a", 1), ("b", 2)]);
-        let cs = schema.input_field_combinations(&fs);
-        assert_eq!(1, cs.len());
+        // Hence the result is 3 combinations i.e. 3 replicas.
+        let fs = ifc_input(vec![("a", 1), ("b", 2)]);
+        let mut cs = schema.input_field_combinations(&fs);
+
+        // To make the order of returned combinations deterministic,
+        // sort them by sum of the field values.
+        ifc_sort_result(&mut cs);
+
+        assert_eq!(3, cs.len());
         let mut ec1 = HashMap::with_capacity(1);
         ec1.insert("a", &FieldValue::Int(1));
-        ec1.insert("b", &FieldValue::Int(2));
-        assert_eq!(ec1, cs[0]);
+        let mut ec2 = HashMap::with_capacity(1);
+        ec2.insert("b", &FieldValue::Int(2));
+        let mut ec3 = HashMap::with_capacity(2);
+        ec3.insert("a", &FieldValue::Int(1));
+        ec3.insert("b", &FieldValue::Int(2));
+        assert_eq!(vec![ec1, ec2, ec3], cs);
 
-        // The input contains fields "b" and "c" only. There is no
-        // supported `AND` condition that includes these 2 fields. But
-        // we need the "all fields" replica to support individual
-        // field matches and OR conditions.
+        // Test case 3: The input contains fields "b" and "c"
+        // only. There is no supported `AND` condition that includes
+        // these 2 fields. But we need the "all fields" replica is
+        // created any way. Hence the following replicas are relevant
+        // to this vector
         //
-        // Hence the result is 1 combination i.e. 1 replica
-        let fs = input_fields(vec![("b", 3), ("c", 2)]);
-        let cs = schema.input_field_combinations(&fs);
-        assert_eq!(1, cs.len());
-        let mut ec1 = HashMap::with_capacity(1);
-        ec1.insert("b", &FieldValue::Int(3));
-        ec1.insert("c", &FieldValue::Int(2));
-        assert_eq!(ec1, cs[0]);
-
-        // The input contains all 3 fields. So considering the
-        // supported conditions, 3 combinations or replicas are required
-        //
-        //   1. to match "a == x and b == y"
-        //   2. to match "a == x and c == z"
-        //   3. all fields replica for individual fields and OR queries
-        let fs = input_fields(vec![("a", 4), ("b", 5), ("c", 6)]);
+        //   1. matches "b"
+        //   2. matches "c"
+        //   3. matches "b AND c"
+        let fs = ifc_input(vec![("b", 3), ("c", 2)]);
         let mut cs = schema.input_field_combinations(&fs);
         // To make the order of returned combinations deterministic,
         // sort them by sum of the field values.
-        cs.sort_by_key(|c| {
-            c.values()
-                .map(|v| match v {
-                    FieldValue::Int(i) => *i,
-                    FieldValue::String(_) => 0,
-                })
-                .sum::<i32>()
-        });
+        ifc_sort_result(&mut cs);
         assert_eq!(3, cs.len());
+        let mut ec1 = HashMap::with_capacity(1);
+        ec1.insert("c", &FieldValue::Int(2));
+        let mut ec2 = HashMap::with_capacity(1);
+        ec2.insert("b", &FieldValue::Int(3));
+        let mut ec3 = HashMap::with_capacity(2);
+        ec3.insert("b", &FieldValue::Int(3));
+        ec3.insert("c", &FieldValue::Int(2));
+        assert_eq!(vec![ec1, ec2, ec3], cs);
+
+        // Test case 4: The input contains all 3 fields. So
+        // considering the supported conditions, 6 combinations or
+        // replicas are relevant to this vector
+        //
+        //   1. matches "a"
+        //   2. matches "b"
+        //   3. matches "c"
+        //   4. matches "a AND b"
+        //   5. to match "a AND c"
+        //   6. all fields replica
+        let fs = ifc_input(vec![("a", 4), ("b", 5), ("c", 6)]);
+        let mut cs = schema.input_field_combinations(&fs);
+        // To make the order of returned combinations deterministic,
+        // sort them by sum of the field values.
+        ifc_sort_result(&mut cs);
+        assert_eq!(6, cs.len());
 
         let mut ec1 = HashMap::new();
         ec1.insert("a", &FieldValue::Int(4));
-        ec1.insert("b", &FieldValue::Int(5));
 
         let mut ec2 = HashMap::new();
-        ec2.insert("a", &FieldValue::Int(4));
-        ec2.insert("c", &FieldValue::Int(6));
+        ec2.insert("b", &FieldValue::Int(5));
 
         let mut ec3 = HashMap::new();
-        ec3.insert("a", &FieldValue::Int(4));
-        ec3.insert("b", &FieldValue::Int(5));
         ec3.insert("c", &FieldValue::Int(6));
 
-        assert_eq!(ec1, cs[0]);
-        assert_eq!(ec2, cs[1]);
-        assert_eq!(ec3, cs[2]);
+        let mut ec4 = HashMap::new();
+        ec4.insert("a", &FieldValue::Int(4));
+        ec4.insert("b", &FieldValue::Int(5));
 
-        // When the input contains no fields
+        let mut ec5 = HashMap::new();
+        ec5.insert("a", &FieldValue::Int(4));
+        ec5.insert("c", &FieldValue::Int(6));
+
+        let mut ec6 = HashMap::new();
+        ec6.insert("a", &FieldValue::Int(4));
+        ec6.insert("b", &FieldValue::Int(5));
+        ec6.insert("c", &FieldValue::Int(6));
+
+        assert_eq!(vec![ec1, ec2, ec3, ec4, ec5, ec6], cs);
+
+        // Test case 5: When the input contains no fields
         let fs = HashMap::new();
         let cs = schema.input_field_combinations(&fs);
         assert!(cs.is_empty());
@@ -546,7 +591,7 @@ mod tests {
 
         // Case 1: When only "age" field is specified in input vector
 
-        let mut fields = HashMap::with_capacity(2);
+        let mut fields = HashMap::with_capacity(1);
         fields.insert("age".to_owned(), FieldValue::Int(5));
         let wd = schema.weighted_dimensions(&fields, 1024).unwrap();
         let exp_dim1 = vec![
@@ -563,23 +608,53 @@ mod tests {
         fields.insert("age".to_owned(), FieldValue::Int(5));
         fields.insert("group".to_owned(), FieldValue::String("a".to_owned()));
         let wd = schema.weighted_dimensions(&fields, 1024).unwrap();
-        let exp_dim1 = vec![
-            0, 1024, 0, 1024, // 5 (original value: 5)
-            0, 1024, // 1 (original value: a)
-            0, 0, // (not specified)
+        let exp = vec![
+            vec![
+                0, 1024, 0, 1024, // 5 (original value: 5)
+                0, 0,             // no high weights
+                0, 0,             // no high weights
+            ],
+            vec![
+                0, 0, 0, 0,       // no high weights
+                0, 1024,          // 1 (original value: a)
+                0, 0,             // no high weights
+            ],
+            vec![
+                0, 1024, 0, 1024, // 5 (original value: 5)
+                0, 1024,          // 1 (original value: a)
+                0, 0,             // (not specified)
+            ],
         ];
-        assert_eq!(vec![exp_dim1], wd);
+        // Convert both to sets for comparing unordered values
+        let wd_set = wd.into_iter().collect::<HashSet<Vec<i32>>>();
+        let exp_set = exp.into_iter().collect::<HashSet<Vec<i32>>>();
+        assert_eq!(exp_set, wd_set);
 
         let mut fields = HashMap::with_capacity(2);
         fields.insert("age".to_owned(), FieldValue::Int(3));
         fields.insert("group".to_owned(), FieldValue::String("c".to_owned()));
         let wd = schema.weighted_dimensions(&fields, 1024).unwrap();
-        let exp_dim1 = vec![
-            0, 0, 1024, 1024, // 3 (original value: 3)
-            1024, 1024, // 3 (original value: c)
-            0, 0, // (not specified)
+        let exp = vec![
+            vec![
+                0, 0, 1024, 1024, // 3 (original value: 3)
+                0, 0,             // no high weights
+                0, 0,             // no high weights
+            ],
+            vec![
+                0, 0, 0, 0,       // no high weights
+                1024, 1024,       // 3 (original value: c)
+                0, 0,             // no high weights
+            ],
+            vec![
+                0, 0, 1024, 1024, // 3 (original value: 3)
+                1024, 1024,       // 3 (original value: c)
+                0, 0,             // (not specified)
+            ]
         ];
-        assert_eq!(vec![exp_dim1], wd);
+        // Convert both to sets for comparing unordered values
+        let wd_set = wd.into_iter().collect::<HashSet<Vec<i32>>>();
+        let exp_set = exp.into_iter().collect::<HashSet<Vec<i32>>>();
+        assert_eq!(exp_set, wd_set);
 
         // Case 3: When all fields are specified in input vector
 
@@ -589,28 +664,48 @@ mod tests {
         fields.insert("level".to_owned(), FieldValue::String("third".to_owned()));
         let wd = schema.weighted_dimensions(&fields, 1024).unwrap();
 
-        // dimensions to support AND(age, group)
-        let exp_dim1 = vec![
-            0, 1024, 0, 1024, // 5 (original value: 5)
-            0, 1024, // 1 (original value: a)
-            0, 0,
+        let exp = vec![
+            // dimensions to support queries for individual field age
+            vec![
+                0, 1024, 0, 1024, // 5 (original value: 5)
+                0, 0,             // no high weights
+                0, 0,             // no high weights
+            ],
+            // dimensions to support queries for individual field group
+            vec![
+                0, 0, 0, 0,      // no high weights
+                0, 1024,         // 0 (original value: a)
+                0, 0,            // no high weights
+            ],
+            // dimensions to support queries for individual field level
+            vec![
+                0, 0, 0, 0,      // no high weights
+                0, 0,            // no high weights
+                1024, 1024,      // 3 (original value: third)
+            ],
+            // dimensions to support AND(age, group)
+            vec![
+                0, 1024, 0, 1024, // 5 (original value: 5)
+                0, 1024,          // 1 (original value: a)
+                0, 0,             // no high weights
+            ],
+            // dimensions to support AND(age, level)
+            vec![
+                0, 1024, 0, 1024, // 5 (original value: 5)
+                0, 0,             // no high weights
+                1024, 1024,       // 3 (original value: third)
+            ],
+            // all fields dimensions to support OR queries
+            vec![
+                0, 1024, 0, 1024, // 5 (original value: 5)
+                0, 1024,          // 0 (original value: a)
+                1024, 1024,       // 3 (original value: third)
+            ],
         ];
-
-        // dimensions to support AND(age, level)
-        let exp_dim2 = vec![
-            0, 1024, 0, 1024, // 5 (original value: 5)
-            0, 0, 1024, 1024, // 3 (original value: third)
-        ];
-
-        // all fields dimensions to support individual field and OR queries
-        let exp_dim3 = vec![
-            0, 1024, 0, 1024, // 5 (original value: 5)
-            0, 1024, // 0 (original value: a)
-            1024, 1024, // 3 (original value: third)
-        ];
-        for dim in wd {
-            assert!(dim == exp_dim1 || dim == exp_dim2 || dim == exp_dim3);
-        }
+        // Convert both to sets for comparing unordered values
+        let wd_set = wd.into_iter().collect::<HashSet<Vec<i32>>>();
+        let exp_set = exp.into_iter().collect::<HashSet<Vec<i32>>>();
+        assert_eq!(exp_set, wd_set);
 
         // Case 4: When no fields are specified in input vector
         let fields = HashMap::new();

--- a/src/metadata/schema.rs
+++ b/src/metadata/schema.rs
@@ -204,10 +204,7 @@ impl MetadataSchema {
         // Note that it's possible that this combination has already
         // been considered before, but it will get deduped when
         // inserting into the HashSet of combinations.
-        let mut all_fields_combination = input_fields_set
-            .iter()
-            .map(|s| *s)
-            .collect::<Vec<&str>>();
+        let mut all_fields_combination = input_fields_set.iter().copied().collect::<Vec<&str>>();
         all_fields_combination.sort();
         combinations.insert(all_fields_combination);
 
@@ -243,7 +240,7 @@ impl MetadataSchema {
         fields: &HashMap<FieldName, FieldValue>,
         weight: i32,
     ) -> Result<Vec<MetadataDimensions>, Error> {
-        let field_combinations = self.input_field_combinations(&fields);
+        let field_combinations = self.input_field_combinations(fields);
         // We cache the results of calling fn `decimal_to_binary_vec`
         // as there's a chance it would get called multiple times for
         // the same input
@@ -254,7 +251,7 @@ impl MetadataSchema {
             for field in &self.fields {
                 let mut field_dims = match field_combination.get(&field.name.as_ref()) {
                     Some(value) => {
-                        let value_id = field.value_id(&value)?;
+                        let value_id = field.value_id(value)?;
                         let size = field.num_dims as usize;
                         match cache.get(&(value_id, size)) {
                             Some(r) => r.clone(),
@@ -265,7 +262,7 @@ impl MetadataSchema {
                                     .collect::<Vec<i32>>();
                                 cache.insert((value_id, size), dims.clone());
                                 dims
-                            },
+                            }
                         }
                     }
                     None => vec![0; field.num_dims as usize],
@@ -428,11 +425,10 @@ mod tests {
     fn ifc_sort_result(result: &mut Vec<HashMap<&str, &FieldValue>>) {
         result.sort_by_key(|c| {
             c.values()
-                .map(|v| {
-                    match v {
-                        FieldValue::Int(i) => *i,
-                        FieldValue::String(_) => 0,
-                    }})
+                .map(|v| match v {
+                    FieldValue::Int(i) => *i,
+                    FieldValue::String(_) => 0,
+                })
                 .sum::<i32>()
         })
     }
@@ -611,18 +607,18 @@ mod tests {
         let exp = vec![
             vec![
                 0, 1024, 0, 1024, // 5 (original value: 5)
-                0, 0,             // no high weights
-                0, 0,             // no high weights
+                0, 0, // no high weights
+                0, 0, // no high weights
             ],
             vec![
-                0, 0, 0, 0,       // no high weights
-                0, 1024,          // 1 (original value: a)
-                0, 0,             // no high weights
+                0, 0, 0, 0, // no high weights
+                0, 1024, // 1 (original value: a)
+                0, 0, // no high weights
             ],
             vec![
                 0, 1024, 0, 1024, // 5 (original value: 5)
-                0, 1024,          // 1 (original value: a)
-                0, 0,             // (not specified)
+                0, 1024, // 1 (original value: a)
+                0, 0, // (not specified)
             ],
         ];
         // Convert both to sets for comparing unordered values
@@ -637,19 +633,19 @@ mod tests {
         let exp = vec![
             vec![
                 0, 0, 1024, 1024, // 3 (original value: 3)
-                0, 0,             // no high weights
-                0, 0,             // no high weights
+                0, 0, // no high weights
+                0, 0, // no high weights
             ],
             vec![
-                0, 0, 0, 0,       // no high weights
-                1024, 1024,       // 3 (original value: c)
-                0, 0,             // no high weights
+                0, 0, 0, 0, // no high weights
+                1024, 1024, // 3 (original value: c)
+                0, 0, // no high weights
             ],
             vec![
                 0, 0, 1024, 1024, // 3 (original value: 3)
-                1024, 1024,       // 3 (original value: c)
-                0, 0,             // (not specified)
-            ]
+                1024, 1024, // 3 (original value: c)
+                0, 0, // (not specified)
+            ],
         ];
         // Convert both to sets for comparing unordered values
         let wd_set = wd.into_iter().collect::<HashSet<Vec<i32>>>();
@@ -668,38 +664,38 @@ mod tests {
             // dimensions to support queries for individual field age
             vec![
                 0, 1024, 0, 1024, // 5 (original value: 5)
-                0, 0,             // no high weights
-                0, 0,             // no high weights
+                0, 0, // no high weights
+                0, 0, // no high weights
             ],
             // dimensions to support queries for individual field group
             vec![
-                0, 0, 0, 0,      // no high weights
-                0, 1024,         // 0 (original value: a)
-                0, 0,            // no high weights
+                0, 0, 0, 0, // no high weights
+                0, 1024, // 0 (original value: a)
+                0, 0, // no high weights
             ],
             // dimensions to support queries for individual field level
             vec![
-                0, 0, 0, 0,      // no high weights
-                0, 0,            // no high weights
-                1024, 1024,      // 3 (original value: third)
+                0, 0, 0, 0, // no high weights
+                0, 0, // no high weights
+                1024, 1024, // 3 (original value: third)
             ],
             // dimensions to support AND(age, group)
             vec![
                 0, 1024, 0, 1024, // 5 (original value: 5)
-                0, 1024,          // 1 (original value: a)
-                0, 0,             // no high weights
+                0, 1024, // 1 (original value: a)
+                0, 0, // no high weights
             ],
             // dimensions to support AND(age, level)
             vec![
                 0, 1024, 0, 1024, // 5 (original value: 5)
-                0, 0,             // no high weights
-                1024, 1024,       // 3 (original value: third)
+                0, 0, // no high weights
+                1024, 1024, // 3 (original value: third)
             ],
             // all fields dimensions to support OR queries
             vec![
                 0, 1024, 0, 1024, // 5 (original value: 5)
-                0, 1024,          // 0 (original value: a)
-                1024, 1024,       // 3 (original value: third)
+                0, 1024, // 0 (original value: a)
+                1024, 1024, // 3 (original value: third)
             ],
         ];
         // Convert both to sets for comparing unordered values

--- a/src/metadata/schema.rs
+++ b/src/metadata/schema.rs
@@ -189,20 +189,16 @@ impl MetadataSchema {
             }
         }
         // Add a combination for all fields in the schema. This is
-        // equivalent to a condition And(<all fields>). To get this,
-        // we compute the intersection of all fields supported by the
-        // schema with actual fields associated with the vector.
+        // equivalent to a condition And(<all fields>). Even thought
+        // it's named 'all_fields_combination', we only consider the
+        // fields that are present in the input.
         //
         // Note that it's possible that this combination has already
         // been considered before, but it will get deduped when
         // inserting into the HashSet of combinations.
-        let mut all_fields_combination = self
-            .fields
+        let mut all_fields_combination = input_fields_set
             .iter()
-            .map(|f| f.name.as_ref())
-            .collect::<HashSet<&str>>()
-            .intersection(&input_fields_set)
-            .copied()
+            .map(|s| *s)
             .collect::<Vec<&str>>();
         all_fields_combination.sort();
         combinations.insert(all_fields_combination);

--- a/src/models/common.rs
+++ b/src/models/common.rs
@@ -410,6 +410,13 @@ pub fn remove_duplicates_and_filter(
     collected
 }
 
+/// Returns inverse of probabilities for every HNSW level
+///
+/// Note that the arg `num_levels` represents HNSW levels, hence level
+/// 0 gets implicitly added to the result i.e. if num_levels = 9, then
+/// the result will be a vector of size 10 with the last element
+/// corresponding to level 0, for which the inverse probability will
+/// be 0
 pub fn generate_level_probs(x: f64, num_levels: u8) -> Vec<(f64, u8)> {
     let mut result = Vec::new();
     for n in (0..=num_levels).rev() {
@@ -684,5 +691,30 @@ impl<K: Eq + Hash, V> TSHashTable<K, V> {
             let ht = ht.lock().unwrap();
             ht.iter().for_each(|(k, v)| f(k, v));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::generate_level_probs;
+
+    #[test]
+    // @NOTE: This test is added mainly for understanding the
+    // implementation
+    fn test_generate_level_probs() {
+        let lp = generate_level_probs(10.0, 9);
+        let expected = vec![
+            (0.999999999, 9),
+            (0.99999999, 8),
+            (0.9999999, 7),
+            (0.999999, 6),
+            (0.99999, 5),
+            (0.9999, 4),
+            (0.999, 3),
+            (0.99, 2),
+            (0.9, 1),
+            (0.0, 0),
+        ];
+        assert_eq!(expected, lp);
     }
 }

--- a/src/models/embedding_persist.rs
+++ b/src/models/embedding_persist.rs
@@ -111,6 +111,7 @@ mod tests {
             raw_vec: Arc::new(raw_vec),
             hash_vec: VectorId(rng.gen()),
             raw_metadata: None,
+            is_pseudo: false,
         }
     }
 

--- a/src/models/types.rs
+++ b/src/models/types.rs
@@ -145,13 +145,19 @@ pub struct NodePropMetadata {
 
 #[derive(Debug)]
 pub struct VectorData<'a> {
+    // Vector id (use specified one and not the internal replica
+    // id). It's not being used any where but occasionally useful for
+    // debugging. In case it's a query vector, `id` expected to be
+    // None.
+    pub id: Option<&'a VectorId>,
     pub quantized_vec: &'a Storage,
     pub metadata: Option<&'a Metadata>,
 }
 
 impl<'a> VectorData<'a> {
-    pub fn without_metadata(qvec: &'a Storage) -> Self {
+    pub fn without_metadata(id: Option<&'a VectorId>, qvec: &'a Storage) -> Self {
         Self {
+            id,
             quantized_vec: qvec,
             metadata: None,
         }

--- a/src/models/types.rs
+++ b/src/models/types.rs
@@ -270,22 +270,22 @@ pub enum DistanceMetric {
 
 impl DistanceFunction for DistanceMetric {
     type Item = MetricResult;
-    fn calculate(&self, x: &VectorData, y: &VectorData) -> Result<Self::Item, DistanceError> {
+    fn calculate(&self, x: &VectorData, y: &VectorData, is_indexing: bool) -> Result<Self::Item, DistanceError> {
         match self {
             Self::Cosine => {
-                let value = CosineSimilarity(0.0).calculate(x, y)?;
+                let value = CosineSimilarity(0.0).calculate(x, y, is_indexing)?;
                 Ok(MetricResult::CosineSimilarity(value))
             }
             Self::Euclidean => {
-                let value = EuclideanDistance(0.0).calculate(x, y)?;
+                let value = EuclideanDistance(0.0).calculate(x, y, is_indexing)?;
                 Ok(MetricResult::EuclideanDistance(value))
             }
             Self::Hamming => {
-                let value = HammingDistance(0.0).calculate(x, y)?;
+                let value = HammingDistance(0.0).calculate(x, y, is_indexing)?;
                 Ok(MetricResult::HammingDistance(value))
             }
             Self::DotProduct => {
-                let value = DotProductDistance(0.0).calculate(x, y)?;
+                let value = DotProductDistance(0.0).calculate(x, y, is_indexing)?;
                 Ok(MetricResult::DotProductDistance(value))
             }
         }

--- a/src/models/types.rs
+++ b/src/models/types.rs
@@ -276,7 +276,12 @@ pub enum DistanceMetric {
 
 impl DistanceFunction for DistanceMetric {
     type Item = MetricResult;
-    fn calculate(&self, x: &VectorData, y: &VectorData, is_indexing: bool) -> Result<Self::Item, DistanceError> {
+    fn calculate(
+        &self,
+        x: &VectorData,
+        y: &VectorData,
+        is_indexing: bool,
+    ) -> Result<Self::Item, DistanceError> {
         match self {
             Self::Cosine => {
                 let value = CosineSimilarity(0.0).calculate(x, y, is_indexing)?;

--- a/src/models/types.rs
+++ b/src/models/types.rs
@@ -176,16 +176,15 @@ impl<'a> VectorData<'a> {
                 if m.mag == 0.0 {
                     ReplicaNodeKind::Base
                 } else {
-                    let vec_mag = match self.quantized_vec {
-                        Storage::UnsignedByte { mag, .. } => mag,
-                        Storage::SubByte { mag, .. } => mag,
-                        Storage::HalfPrecisionFP { mag, .. } => mag,
-                        Storage::FullPrecisionFP { mag, .. } => mag,
-                    };
-                    if *vec_mag == 0.0 {
-                        ReplicaNodeKind::Pseudo
-                    } else {
-                        ReplicaNodeKind::Metadata
+                    match self.id {
+                        Some(id) => {
+                            if id.0 == u64::pow(2, 56) - 1 {
+                                ReplicaNodeKind::Pseudo
+                            } else {
+                                ReplicaNodeKind::Metadata
+                            }
+                        }
+                        None => ReplicaNodeKind::Metadata,
                     }
                 }
             }

--- a/src/models/types.rs
+++ b/src/models/types.rs
@@ -30,7 +30,7 @@ use crate::{
         inverted::{data::InvertedIndexData, InvertedIndex},
         tf_idf::{data::TFIDFIndexData, TFIDFIndex},
     },
-    metadata::{schema::MetadataDimensions, QueryFilterDimensions},
+    metadata::{schema::MetadataDimensions, QueryFilterDimensions, HIGH_WEIGHT},
     models::{
         buffered_io::BufIoError, common::*, meta_persist::retrieve_values_range, versioning::*,
     },
@@ -144,6 +144,13 @@ pub struct NodePropMetadata {
 }
 
 #[derive(Debug)]
+pub enum ReplicaNodeKind {
+    Pseudo,
+    Base,
+    Metadata,
+}
+
+#[derive(Debug)]
 pub struct VectorData<'a> {
     // Vector id (use specified one and not the internal replica
     // id). It's not being used any where but occasionally useful for
@@ -160,6 +167,36 @@ impl<'a> VectorData<'a> {
             id,
             quantized_vec: qvec,
             metadata: None,
+        }
+    }
+
+    pub fn replica_node_kind(&self) -> ReplicaNodeKind {
+        match self.metadata {
+            Some(m) => {
+                if m.mag == 0.0 {
+                    ReplicaNodeKind::Base
+                } else {
+                    let vec_mag = match self.quantized_vec {
+                        Storage::UnsignedByte { mag, .. } => mag,
+                        Storage::SubByte { mag, .. } => mag,
+                        Storage::HalfPrecisionFP { mag, .. } => mag,
+                        Storage::FullPrecisionFP { mag, .. } => mag,
+                    };
+                    if *vec_mag == 0.0 {
+                        ReplicaNodeKind::Pseudo
+                    } else {
+                        ReplicaNodeKind::Metadata
+                    }
+                }
+            }
+            None => ReplicaNodeKind::Base,
+        }
+    }
+
+    pub fn is_pseudo_root(&self) -> bool {
+        match self.metadata {
+            Some(m) => m.mbits == vec![HIGH_WEIGHT; m.mbits.len()],
+            None => false,
         }
     }
 }

--- a/src/vector_store.rs
+++ b/src/vector_store.rs
@@ -217,24 +217,25 @@ pub fn ann_search(
                         quantized_vec: &fvec,
                         metadata: Some(&fvec_metadata),
                     };
-                    let d = hnsw_index
-                        .distance_metric
-                        .read()
-                        .unwrap()
-                        .calculate(&fvec_data, &cur_node_data, false)?;
+                    let d = hnsw_index.distance_metric.read().unwrap().calculate(
+                        &fvec_data,
+                        &cur_node_data,
+                        false,
+                    )?;
                     dists.push(d)
                 }
                 dists.into_iter().min().unwrap()
             }
             None => {
                 let fvec_data = VectorData::without_metadata(None, &fvec);
-                let cur_node_data = VectorData::without_metadata(Some(cur_node_id), &cur_node.prop_value.vec);
-                hnsw_index
-                    .distance_metric
-                    .read()
-                    .unwrap()
-                    .calculate(&fvec_data, &cur_node_data, false)?
-            },
+                let cur_node_data =
+                    VectorData::without_metadata(Some(cur_node_id), &cur_node.prop_value.vec);
+                hnsw_index.distance_metric.read().unwrap().calculate(
+                    &fvec_data,
+                    &cur_node_data,
+                    false,
+                )?
+            }
         };
         vec![(cur_entry, dist)]
     } else {
@@ -888,11 +889,11 @@ pub fn index_embedding(
             quantized_vec: &cur_node.prop_value.vec,
             metadata: cur_node_metadata.as_deref(),
         };
-        let dist = hnsw_index
-            .distance_metric
-            .read()
-            .unwrap()
-            .calculate(&fvec_data, &cur_node_data, true)?;
+        let dist = hnsw_index.distance_metric.read().unwrap().calculate(
+            &fvec_data,
+            &cur_node_data,
+            true,
+        )?;
         vec![(cur_entry, dist)]
     } else {
         z
@@ -1305,7 +1306,8 @@ fn traverse_find_nearest(
                     quantized_vec: &neighbor_data.prop_value.vec,
                     metadata: neighbor_metadata.as_deref(),
                 };
-                let dist = distance_metric.calculate(&fvec_data, &neighbor_vec_data, is_indexing)?;
+                let dist =
+                    distance_metric.calculate(&fvec_data, &neighbor_vec_data, is_indexing)?;
                 skipm.insert(neighbor_id);
                 candidate_queue.push((dist, neighbor_node));
             }

--- a/src/vector_store.rs
+++ b/src/vector_store.rs
@@ -218,7 +218,7 @@ pub fn ann_search(
                         .distance_metric
                         .read()
                         .unwrap()
-                        .calculate(&fvec_data, &cur_node_data)?;
+                        .calculate(&fvec_data, &cur_node_data, false)?;
                     dists.push(d)
                 }
                 dists.into_iter().min().unwrap()
@@ -230,8 +230,8 @@ pub fn ann_search(
                     .distance_metric
                     .read()
                     .unwrap()
-                    .calculate(&fvec_data, &cur_node_data)?
-            }
+                    .calculate(&fvec_data, &cur_node_data, false)?
+            },
         };
         vec![(cur_entry, dist)]
     } else {
@@ -885,7 +885,7 @@ pub fn index_embedding(
             .distance_metric
             .read()
             .unwrap()
-            .calculate(&fvec_data, &cur_node_data)?;
+            .calculate(&fvec_data, &cur_node_data, true)?;
         vec![(cur_entry, dist)]
     } else {
         z
@@ -1256,7 +1256,7 @@ fn traverse_find_nearest(
         quantized_vec: &start_data.prop_value.vec,
         metadata: start_metadata.as_deref(),
     };
-    let start_dist = distance_metric.calculate(&fvec_data, &start_vec_data)?;
+    let start_dist = distance_metric.calculate(&fvec_data, &start_vec_data, is_indexing)?;
 
     let start_id = start_data.get_id().0 as u32;
     skipm.insert(start_id);
@@ -1295,7 +1295,7 @@ fn traverse_find_nearest(
                     quantized_vec: &neighbor_data.prop_value.vec,
                     metadata: neighbor_metadata.as_deref(),
                 };
-                let dist = distance_metric.calculate(&fvec_data, &neighbor_vec_data)?;
+                let dist = distance_metric.calculate(&fvec_data, &neighbor_vec_data, is_indexing)?;
                 skipm.insert(neighbor_id);
                 candidate_queue.push((dist, neighbor_node));
             }

--- a/src/vector_store.rs
+++ b/src/vector_store.rs
@@ -701,7 +701,6 @@ fn preprocess_embedding(
         // @TODO(vineet): This is hacky
         let num_levels = hnsw_index.levels_prob.len() - 1;
         let plp = pseudo_level_probs(num_levels as u8, replicas.len() as u16);
-        println!("----- pseudo_level_probs = {plp:?}");
         let mut embeddings: Vec<IndexableEmbedding> = vec![];
         let mut is_first_overrideen = false;
         for prop_metadata in replicas {
@@ -713,7 +712,6 @@ fn preprocess_embedding(
             } else {
                 plp.clone()
             };
-            // println!("----- {overridden_level_probs:?}");
             let emb = IndexableEmbedding {
                 prop_value: prop_value.clone(),
                 prop_metadata: Some(Arc::new(prop_metadata)),
@@ -1391,6 +1389,11 @@ fn traverse_find_nearest(
                 }
             };
 
+            // @TODO(vineet): The problem seems to be that neighbor_id
+            // is always the same when indexing pseudo node
+            // replicas. This is because the ids of base node and the
+            // pseudo node are > u32::MAX, whereas neighbor_id is of
+            // type u32. Hence they get truncated to u32::MAX - 1.
             if !skipm.is_member(neighbor_id) {
                 let neighbor_data = unsafe { &*neighbor_node }.try_get_data(&hnsw_index.cache)?;
                 let neighbor_metadata =

--- a/src/vector_store.rs
+++ b/src/vector_store.rs
@@ -173,6 +173,7 @@ pub fn ann_search(
                     &hnsw_index,
                     cur_entry,
                     &fvec,
+                    None,
                     Some(&mdims),
                     &mut 0,
                     &mut skipm,
@@ -199,6 +200,7 @@ pub fn ann_search(
             &hnsw_index,
             cur_entry,
             &fvec,
+            None,
             None,
             &mut 0,
             &mut skipm,
@@ -959,6 +961,7 @@ pub fn index_embedding(
         hnsw_index,
         cur_entry,
         &fvec,
+        Some(&prop_value.id),
         mdims.as_deref(),
         &mut 0,
         &mut skipm,
@@ -1331,6 +1334,7 @@ fn traverse_find_nearest(
     hnsw_index: &HNSWIndex,
     start_node: SharedNode,
     fvec: &Storage,
+    fvec_id: Option<&VectorId>,
     mdims: Option<&Metadata>,
     nodes_visited: &mut u32,
     skipm: &mut PerformantFixedSet,
@@ -1345,7 +1349,7 @@ fn traverse_find_nearest(
     let start_data = unsafe { &*start_version }.try_get_data(&hnsw_index.cache)?;
 
     let fvec_data = VectorData {
-        id: None,
+        id: fvec_id,
         quantized_vec: fvec,
         metadata: mdims,
     };

--- a/src/vector_store.rs
+++ b/src/vector_store.rs
@@ -33,6 +33,7 @@ use crate::storage::Storage;
 use lmdb::Transaction;
 use rand::Rng;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::fs::File;
 use std::ptr;
@@ -169,11 +170,11 @@ pub fn ann_search(
                 // (thanks to the `skipm` argument)
                 z_candidates.append(&mut z_with_mdims);
             }
+
             // Sort candidates by distance (asc)
-            z_candidates.sort_by_key(|c| c.1);
+            z_candidates.sort_by_key(|c| Reverse(c.1));
             z_candidates
                 .into_iter()
-                .rev() // Reverse the order (to get descending order)
                 .take(100) // Limit the number of results
                 .collect::<Vec<_>>()
         }

--- a/src/vector_store.rs
+++ b/src/vector_store.rs
@@ -11,8 +11,10 @@ use crate::indexes::hnsw::HNSWIndex;
 use crate::macros::key;
 use crate::metadata;
 use crate::metadata::fields_to_dimensions;
+use crate::metadata::pseudo_level_probs;
 use crate::metadata::MetadataFields;
 use crate::metadata::MetadataSchema;
+use crate::metadata::HIGH_WEIGHT;
 use crate::models::buffered_io::*;
 use crate::models::common::*;
 use crate::models::dot_product::dot_product_f32;
@@ -143,9 +145,6 @@ pub fn ann_search(
     });
     skipm.insert(vector_emb.hash_vec.0 as u32);
 
-    let cur_node = unsafe { &*cur_entry }.try_get_data(&hnsw_index.cache)?;
-    let cur_node_id = &cur_node.prop_value.id;
-
     let z = match query_filter_dims {
         Some(qf_dims) => {
             let mut z_candidates: Vec<(SharedNode, MetricResult)> = vec![];
@@ -193,6 +192,8 @@ pub fn ann_search(
     };
 
     let mut z = if z.is_empty() {
+        let cur_node = unsafe { &*cur_entry }.try_get_data(&hnsw_index.cache)?;
+        let cur_node_id = &cur_node.prop_value.id;
         let dist = match query_filter_dims {
             // In case of metadata filters in query, we calculate the
             // distances between the cur_node and all query filter
@@ -444,8 +445,11 @@ pub fn index_embeddings_batch(
             )
         })
         .map(|emb| {
-            let max_level =
-                get_max_insert_level(rand::random::<f32>().into(), &hnsw_index.levels_prob);
+            // @TODO: Calculate max_level accordingly
+            let max_level = match emb.overridden_level_probs {
+                Some(lp) => get_max_insert_level(rand::random::<f32>().into(), &lp),
+                None => get_max_insert_level(rand::random::<f32>().into(), &hnsw_index.levels_prob),
+            };
             let root_entry = hnsw_index.get_root_vec();
             let highest_level = HNSWLevel(hnsw_params.num_layers);
 
@@ -481,6 +485,7 @@ struct IndexableEmbedding {
     prop_value: Arc<NodePropValue>,
     prop_metadata: Option<Arc<NodePropMetadata>>,
     embedding: QuantizedDenseVectorEmbedding,
+    overridden_level_probs: Option<Vec<(f64, u8)>>,
 }
 
 /// Computes "metadata replica sets" i.e. all metadata dimensions
@@ -583,6 +588,41 @@ fn prop_metadata_replicas(
     }
 }
 
+fn pseudo_metadata_replicas(
+    schema: &MetadataSchema,
+    prop_file: &RwLock<File>,
+) -> Result<Vec<NodePropMetadata>, WaCustomError> {
+    let dims = schema.pseudo_weighted_dimensions(HIGH_WEIGHT);
+    let replicas = dims
+        .into_iter()
+        .enumerate()
+        .map(|(i, d)| {
+            let mid = MetadataId(i as u8 + 1);
+            let metadata = Metadata::from(d);
+            (mid, metadata)
+        })
+        .collect::<Vec<(MetadataId, Metadata)>>();
+    // As pseudo_replicas will be created only at the time of index
+    // initialization, it's ok to hold a single rw lock for writing
+    // metadata for all replicas to the prop file
+    let mut prop_file_guard = prop_file.write().map_err(|_| {
+        WaCustomError::LockError("Failed to acquire lock to write prop metadata".to_string())
+    })?;
+    let mut result = Vec::with_capacity(replicas.len());
+    for (mid, m) in replicas {
+        let mvalue = Arc::new(m);
+        let location = write_prop_metadata_to_file(&mid, mvalue.clone(), &mut prop_file_guard)?;
+        let prop_metadata = NodePropMetadata {
+            id: mid,
+            vec: mvalue,
+            location,
+        };
+        result.push(prop_metadata);
+    }
+    drop(prop_file_guard);
+    Ok(result)
+}
+
 /// Converts raw embeddings into `IndexableEmbedding` i.e. ready to be
 /// indexed - with quantization performed and property values and
 /// metadata fields converted into appropriate types.
@@ -633,37 +673,69 @@ fn preprocess_embedding(
         .get_collection(&hnsw_index.name)
         .expect("Couldn't get collection from ain_env");
 
-    let metadata_replicas = prop_metadata_replicas(
-        coll.metadata_schema.as_ref(),
-        raw_emb.raw_metadata.as_ref(),
-        &hnsw_index.cache.prop_file,
-    )
-    .unwrap();
+    let metadata_schema = coll.metadata_schema.as_ref();
+    let prop_file = &hnsw_index.cache.prop_file;
 
-    let mut embeddings: Vec<IndexableEmbedding> = vec![];
-
-    match metadata_replicas {
-        Some(replicas) => {
-            for prop_metadata in replicas {
-                let emb = IndexableEmbedding {
-                    prop_value: prop_value.clone(),
-                    prop_metadata: Some(Arc::new(prop_metadata)),
-                    embedding: embedding.clone(),
-                };
-                embeddings.push(emb);
-            }
-        }
-        None => {
+    // @TODO(vineet): Remove unwraps
+    if raw_emb.is_pseudo {
+        let replicas = pseudo_metadata_replicas(metadata_schema.unwrap(), prop_file).unwrap();
+        // @TODO(vineet): This is hacky
+        let num_levels = hnsw_index.levels_prob.len() - 1;
+        let plp = pseudo_level_probs(num_levels as u8, replicas.len() as u16);
+        println!("----- pseudo_level_probs = {plp:?}");
+        let mut embeddings: Vec<IndexableEmbedding> = vec![];
+        let mut is_first_overrideen = false;
+        for prop_metadata in replicas {
+            let overridden_level_probs = if !is_first_overrideen {
+                is_first_overrideen = true;
+                plp.iter()
+                    .map(|(_, lev)| (0.0, *lev))
+                    .collect::<Vec<(f64, u8)>>()
+            } else {
+                plp.clone()
+            };
+            // println!("----- {overridden_level_probs:?}");
             let emb = IndexableEmbedding {
-                prop_value,
-                prop_metadata: None,
+                prop_value: prop_value.clone(),
+                prop_metadata: Some(Arc::new(prop_metadata)),
                 embedding: embedding.clone(),
+                overridden_level_probs: Some(overridden_level_probs),
             };
             embeddings.push(emb);
         }
+        embeddings
+    } else {
+        let metadata_replicas = prop_metadata_replicas(
+            coll.metadata_schema.as_ref(),
+            raw_emb.raw_metadata.as_ref(),
+            &hnsw_index.cache.prop_file,
+        )
+        .unwrap();
+        match metadata_replicas {
+            Some(replicas) => {
+                let mut embeddings: Vec<IndexableEmbedding> = vec![];
+                for prop_metadata in replicas {
+                    let emb = IndexableEmbedding {
+                        prop_value: prop_value.clone(),
+                        prop_metadata: Some(Arc::new(prop_metadata)),
+                        embedding: embedding.clone(),
+                        overridden_level_probs: None,
+                    };
+                    embeddings.push(emb);
+                }
+                embeddings
+            }
+            None => {
+                let emb = IndexableEmbedding {
+                    prop_value,
+                    prop_metadata: None,
+                    embedding: embedding.clone(),
+                    overridden_level_probs: None,
+                };
+                vec![emb]
+            }
+        }
     }
-
-    embeddings
 }
 
 pub fn index_embeddings(
@@ -773,6 +845,7 @@ pub fn index_embeddings_in_transaction(
                     hash_vec: id,
                     raw_vec: Arc::new(values),
                     raw_metadata: metadata,
+                    is_pseudo: false,
                 };
                 transaction.post_raw_embedding(raw_emb.clone());
                 raw_emb

--- a/tests/test_metadata_filters.py
+++ b/tests/test_metadata_filters.py
@@ -357,8 +357,7 @@ def cmd_insert_and_check(ctx, args):
 
 def cmd_query(ctx, args):
     vec_id = args.vector_id
-    result = get_vector_by_id(ctx["vector_db_name"], vec_id)
-    vec = result["Dense"]
+    vec = get_vector_by_id(ctx["vector_db_name"], vec_id)
     values = vec["values"]
     print("Vector metadata:", vec["metadata"])
     metadata_filter = json.loads(args.metadata_filter) if args.metadata_filter else None

--- a/tests/test_metadata_filters.py
+++ b/tests/test_metadata_filters.py
@@ -80,7 +80,7 @@ def create_explicit_index(name):
         "index": {
             "type": "hnsw",
             "properties": {
-                "num_layers": 7,
+                "num_layers": 9,
                 "max_cache_size": 1000,
                 "ef_construction": 512,
                 "ef_search": 256,

--- a/tests/test_metadata_filters.py
+++ b/tests/test_metadata_filters.py
@@ -15,6 +15,7 @@ strongly doesn't match the particular vector.
 
 """
 
+import argparse
 import os
 import getpass
 import requests
@@ -328,43 +329,72 @@ def check_search_results(vector_index, vector_db_name):
         print("-" * 100)
 
 
-def main():
-    # Create database
-    vector_db_name = "testdb"
-    dimensions = 1024
-    # max_val = 1.0
-    # min_val = -1.0
-    # perturbation_degree = 0.95  # Degree of perturbation
-
-    print("Creating session")
-    session_response = create_session()
-
+def cmd_insert_and_check(ctx, args):
     metadata_schema = construct_metadata_schema()
-
+    db_name = ctx["vector_db_name"]
     print("Creating a new db/collection")
     create_collection_response = create_db(
-        name=vector_db_name,
+        name=db_name,
         description="Test collection for vector database",
-        dimension=dimensions,
+        dimension=ctx["dimensions"],
         metadata_schema=metadata_schema,
     )
     coll_id = create_collection_response["id"]
     print("  Create Collection(DB) Response:", create_collection_response)
 
     print("Creating index explicitly")
-    create_index_response = create_explicit_index(vector_db_name)
+    create_index_response = create_explicit_index(db_name)
     print("  Create index response:", create_index_response)
 
-    num_to_insert = 100
-    vectors = gen_vectors(num_to_insert, dimensions, metadata_schema)
+    num_to_insert = args.num_vecs
+    vectors = gen_vectors(num_to_insert, ctx["dimensions"], metadata_schema)
     print(f"Inserting {num_to_insert} vectors")
     vidx = insert_vectors(coll_id, vectors)
 
     print("Running search queries")
-    check_search_results(vidx, vector_db_name)
+    check_search_results(vidx, db_name)
 
-    # v = get_vector_by_id(coll_id, 1)
-    # print(v)
+
+def cmd_query(ctx, args):
+    vec_id = args.vector_id
+    result = get_vector_by_id(ctx["vector_db_name"], vec_id)
+    vec = result["Dense"]
+    values = vec["values"]
+    print("Vector metadata:", vec["metadata"])
+    metadata_filter = json.loads(args.metadata_filter) if args.metadata_filter else None
+    res = search_ann(ctx["vector_db_name"], values, metadata_filter)
+    print("Result:", res)
+
+
+def init_ctx():
+    print("Creating session")
+    token = create_session()
+    return {
+        "vector_db_name": "testdb",
+        "dimensions": 1024,
+        # "max_val": 1.0
+        # "min_val": -1.0
+        # perturbation_degree: 0.95,
+        "token": token,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(required=True)
+
+    parser_insert = subparsers.add_parser('insert')
+    parser_insert.add_argument('-n', '--num-vecs', type=int, default=100)
+    parser_insert.set_defaults(func=cmd_insert_and_check)
+
+    parser_query = subparsers.add_parser('query')
+    parser_query.add_argument('vector_id', type=int)
+    parser_query.add_argument('-m', '--metadata-filter', type=str, default=None)
+    parser_query.set_defaults(func=cmd_query)
+
+    args = parser.parse_args()
+    ctx = init_ctx()
+    args.func(ctx, args)
 
 
 if __name__ == "__main__":

--- a/tests/test_metadata_filters.py
+++ b/tests/test_metadata_filters.py
@@ -52,20 +52,9 @@ def create_session():
     return token
 
 
-def create_db(name, description=None, dimension=1024, metadata_schema=None):
+def create_db(vcoll):
     url = f"{base_url}/collections"
-    data = {
-        "name": name,
-        "description": description,
-        "dense_vector": {
-            "enabled": True,
-            "dimension": dimension,
-        },
-        "sparse_vector": {"enabled": False},
-        "tf_idf_options": {"enabled": False},
-        "metadata_schema": metadata_schema,
-        "config": {"max_vectors": None, "replication_factor": None},
-    }
+    data = vcoll.create_db_payload()
     response = requests.post(
         url, headers=generate_headers(), data=json.dumps(data), verify=False
     )
@@ -104,45 +93,16 @@ def create_explicit_index(name):
     return response.json() if response.status_code == 200 and response.text else {}
 
 
-def construct_metadata_schema():
-    age = {
-        "name": "age",
-        "values": [x for x in range(25, 50)],
-    }
-    color = {"name": "color", "values": ["red", "blue", "green"]}
-    fields = [age, color]
-    conds = [
-        {"op": "and", "field_names": ["age", "color"]},
-        {"op": "or", "field_names": ["age", "color"]},
-    ]
-    return {
-        "fields": fields,
-        "supported_conditions": conds,
-    }
-
-
 def prob(percent):
     assert percent <= 100
     return random.random() <= (percent / 100)
 
 
-def gen_metadata_fields(metadata_schema):
-    if metadata_schema is None:
-        return None
-    if prob(2):
-        return None
-    mfields = {}
-    for field in metadata_schema["fields"]:
-        # if prob(70):
-        mfields[field["name"]] = random.choice(field["values"])
-    return mfields
-
-
-def gen_vectors(num, num_dims, metadata_schema):
+def gen_vectors(num, vcoll):
     for i in range(num):
         vid = i + 1
-        values = np.random.uniform(-1, 1, num_dims).tolist()
-        metadata = gen_metadata_fields(metadata_schema)
+        values = np.random.uniform(-1, 1, vcoll.num_dimensions).tolist()
+        metadata = vcoll.gen_metadata_fields()
         yield {"id": vid, "values": values, "metadata": metadata}
 
 
@@ -318,27 +278,240 @@ def check_search_results(vector_index, vector_db_name):
         + queries_ne_age_color
     )
 
-    for query in queries:
-        print("Filter:", query["filter"])
-        res = search_ann(vector_db_name, query["vec"], query["filter"])
+
+def search_and_compare(vector_db_name, test_cases):
+    for tc in test_cases:
+        print("Filter:", tc["filter"])
+        res = search_ann(vector_db_name, tc["vec"], tc["filter"])
         print("Result:", res)
-        test_func = query["test"]
+        test_func = tc["test"]
         (test_name, test_output) = test_func(res)
         test_result = "passed" if test_output else "failed"
         print(f"Test: {test_name} ({test_result})")
         print("-" * 100)
 
 
+class VectorCollection:
+    def __init__(self, name, description, num_dimensions, metadata_schema=None):
+        self.name = name
+        self.description = description
+        self.num_dimensions = num_dimensions
+        self.metadata_schema = metadata_schema
+
+    def create_db_payload(self):
+        return {
+            "name": self.name,
+            "description": self.description,
+            "dense_vector": {
+                "enabled": True,
+                "dimension": self.num_dimensions,
+            },
+            "sparse_vector": {"enabled": False},
+            "tf_idf_options": {"enabled": False},
+            "metadata_schema": self.metadata_schema,
+            "config": {"max_vectors": None, "replication_factor": None},
+        }
+
+    def gen_metadata_fields(self):
+        if self.metadata_schema is None:
+            return None
+        if prob(2):
+            return None
+        mfields = {}
+        for field in self.metadata_schema["fields"]:
+            # if prob(70):
+            mfields[field["name"]] = random.choice(field["values"])
+        return mfields
+
+    def test_cases(self):
+        raise NotImplementedError
+
+
+class VecWithAgeColor(VectorCollection):
+
+    def __init__(self, name, num_dimensions):
+        age = {
+            "name": "age",
+            "values": [x for x in range(25, 50)],
+        }
+        color = {
+            "name": "color",
+            "values": ["red", "blue", "green"]
+        }
+        fields = [age, color]
+        conds = [
+            {"op": "and", "field_names": ["age", "color"]},
+            {"op": "or", "field_names": ["age", "color"]},
+        ]
+        metadata_schema = {
+            "fields": fields,
+            "supported_conditions": conds,
+        }
+        super().__init__(
+            name=name,
+            num_dimensions=num_dimensions,
+            description="vec with fields age, color",
+            metadata_schema=metadata_schema,
+        )
+
+    def test_cases(self, vector_index):
+        max_queries_each = 5
+        queries_eq_age = []
+        queries_eq_color = []
+        queries_eq_age_color = []
+        queries_ne_age = []
+        queries_ne_color = []
+        queries_ne_age_color = []
+        for vec in vector_index.values():
+            m_age = nested_lookup(vec, "metadata", "age")
+            m_color = nested_lookup(vec, "metadata", "color")
+            qvec = vec["values"]
+            if m_age and m_color:
+                if len(queries_eq_age_color) <= max_queries_each:
+                    queries_eq_age_color.append(
+                        {
+                            "vec": qvec,
+                            "filter": and_filter_json(
+                                [
+                                    make_predicate_json("age", "Equal", m_age),
+                                    make_predicate_json("color", "Equal", m_color),
+                                ]
+                            ),
+                            "test": partial(must_match, vec["id"]),
+                        }
+                    )
+                    continue
+                elif len(queries_ne_age_color) <= max_queries_each:
+                    queries_ne_age_color.append(
+                        {
+                            "vec": qvec,
+                            "filter": and_filter_json(
+                                [
+                                    make_predicate_json("age", "NotEqual", m_age),
+                                    make_predicate_json("color", "NotEqual", m_color),
+                                ]
+                            ),
+                            "test": partial(must_not_match, vec["id"]),
+                        }
+                    )
+                    continue
+            if m_age:
+                if len(queries_eq_age) <= max_queries_each:
+                    queries_eq_age.append(
+                        {
+                            "vec": qvec,
+                            "filter": is_filter_json("age", "Equal", m_age),
+                            "test": partial(must_match, vec["id"]),
+                        }
+                    )
+                    continue
+                elif len(queries_ne_age) <= max_queries_each:
+                    queries_ne_age.append(
+                        {
+                            "vec": qvec,
+                            "filter": is_filter_json("age", "NotEqual", m_age),
+                            "test": partial(must_not_match, vec["id"]),
+                        }
+                    )
+                    continue
+            if m_color:
+                if len(queries_eq_color) <= max_queries_each:
+                    queries_eq_color.append(
+                        {
+                            "vec": qvec,
+                            "filter": is_filter_json("color", "Equal", m_color),
+                            "test": partial(must_match, vec["id"]),
+                        }
+                    )
+                    continue
+                elif len(queries_ne_color) <= max_queries_each:
+                    queries_ne_color.append(
+                        {
+                            "vec": qvec,
+                            "filter": is_filter_json("color", "NotEqual", m_color),
+                            "test": partial(must_not_match, vec["id"]),
+                        }
+                    )
+                    continue
+        return (
+            queries_eq_age +
+            queries_eq_color +
+            queries_eq_age_color +
+            queries_ne_age +
+            queries_ne_color +
+            queries_ne_age_color
+        )
+
+
+class VecWithBinaryStatus(VectorCollection):
+
+    def __init__(self, name, num_dimensions):
+        status = {
+            "name": "status",
+            "values": ["todo", "done"],
+        }
+        fields = [status]
+        metadata_schema = {
+            "fields": fields,
+            "supported_conditions": [],
+        }
+        super().__init__(
+            name=name,
+            num_dimensions=num_dimensions,
+            description="vec with binary status",
+            metadata_schema=metadata_schema,
+        )
+
+    def test_cases(self, vector_index):
+        all_vecs = [x for x in vector_index.values()]
+        vecs = random.choices(all_vecs, k=5)
+        get_status = lambda x: nested_lookup(x, "metadata", "status")
+        return [
+            # With no filter
+            {
+                "vec": vecs[0]["values"],
+                "filter": None,
+                "test": partial(must_match, vecs[0]["id"])
+            },
+
+            # With filter status = todo
+            {
+                "vec": vecs[1]["values"],
+                "filter": is_filter_json("status", "Equal", get_status(vecs[1])),
+                "test": partial(must_match, vecs[1]["id"])
+            },
+
+            # With filter status = done
+            {
+                "vec": vecs[2]["values"],
+                "filter": is_filter_json("status", "Equal", get_status(vecs[2])),
+                "test": partial(must_match, vecs[2]["id"])
+            },
+
+            # With filter status != todo
+            {
+                "vec": vecs[3]["values"],
+                "filter": is_filter_json("status", "NotEqual", get_status(vecs[3])),
+                "test": partial(must_not_match, vecs[3]["id"])
+            },
+
+            # With filter status != done
+            {
+                "vec": vecs[4]["values"],
+                "filter": is_filter_json("status", "NotEqual", get_status(vecs[4])),
+                "test": partial(must_not_match, vecs[4]["id"])
+            },
+        ]
+
+
 def cmd_insert_and_check(ctx, args):
-    metadata_schema = construct_metadata_schema()
     db_name = ctx["vector_db_name"]
+    # @NOTE: Replace the following with `VecWithAgeColor` to test that
+    # example. Similarly more such classes can be implemented to test
+    # with different examples.
+    vcoll = VecWithBinaryStatus(db_name, args.num_dims)
     print("Creating a new db/collection")
-    create_collection_response = create_db(
-        name=db_name,
-        description="Test collection for vector database",
-        dimension=ctx["dimensions"],
-        metadata_schema=metadata_schema,
-    )
+    create_collection_response = create_db(vcoll)
     coll_id = create_collection_response["id"]
     print("  Create Collection(DB) Response:", create_collection_response)
 
@@ -347,12 +520,14 @@ def cmd_insert_and_check(ctx, args):
     print("  Create index response:", create_index_response)
 
     num_to_insert = args.num_vecs
-    vectors = gen_vectors(num_to_insert, ctx["dimensions"], metadata_schema)
+    vectors = gen_vectors(num_to_insert, vcoll)
     print(f"Inserting {num_to_insert} vectors")
     vidx = insert_vectors(coll_id, vectors)
 
+    tcs = vcoll.test_cases(vidx)
+
     print("Running search queries")
-    check_search_results(vidx, db_name)
+    search_and_compare(db_name, tcs)
 
 
 def cmd_query(ctx, args):
@@ -370,7 +545,6 @@ def init_ctx():
     token = create_session()
     return {
         "vector_db_name": "testdb",
-        "dimensions": 1024,
         # "max_val": 1.0
         # "min_val": -1.0
         # perturbation_degree: 0.95,
@@ -384,6 +558,7 @@ def main():
 
     parser_insert = subparsers.add_parser('insert')
     parser_insert.add_argument('-n', '--num-vecs', type=int, default=100)
+    parser_insert.add_argument('-d', '--num-dims', type=int, default=1024)
     parser_insert.set_defaults(func=cmd_insert_and_check)
 
     parser_query = subparsers.add_parser('query')


### PR DESCRIPTION
The metadata filtering functionality returns false negatives. To fix it, we're now using the pseudo nodes approach plus a bunch of other changes that deviate from the org document (yet to be updated). This PR includes all those changes but note that the false negatives are not fixed yet because pseudo nodes are not getting indexed correctly. 

This is because the vector ids are of type u64 but the neighbor ids have type u32.  This usually doesn't affect regular vectors inserted by the user. However, the the root node has id = u64::MAX and the pseudo node has id =  2^56-1, so casting them to u32 truncates them to the same value 4294967294 and the `skipm` membership check always returns true in `traverse_find_nearest`.  This is yet to be thought through and fixed. 

The PR is backward compatible though and is ready to be merged. Just that vector stores that support metadata schema may have false negatives (which was already the case). 