### PR TITLE
Add `max_num_replicas` method in MetadataSchema

### DIFF
--- a/src/metadata/query_filtering.rs
+++ b/src/metadata/query_filtering.rs
@@ -112,11 +112,6 @@ pub fn filter_encoded_dimensions(
     }
 }
 
-// Functionality to be implemented
-//
-// 1. [✓] Given `MetadataSchema` and metadata filter, return Equality and
-//    Inequality filter encoding to be appended to the query vector
-
 #[cfg(test)]
 mod tests {
 


### PR DESCRIPTION
This method is to be used for calculating the no. of ids that should be allocated for the replica set of a vector that's inserted in a collection. 

The PR also includes a couple of more commits: 

1. Got rid of the replica for the combination of all fields. It's not required with the new logic where we have separate replicas for matching individual fields and OR conditions (unless there's an AND condition for all fields). 
2. The Vec<SupportedCondition> is deduplicated when initializing MetadataSchema instance. This is because the method to calculate no. of max replicas depends on the length of this vector. 