### PR TITLE
Fix HNSW node versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,7 @@ dependencies = [
  "log",
  "nom",
  "num_cpus",
+ "parking_lot",
  "prost",
  "prost-types",
  "quickcheck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tonic-reflection = { version = "0.12.3", optional = true }
 clap = { version = "4.5.31", features = ["derive"] }
 snowball-stemmer = { git = "https://github.com/cosdata/snowball-stemmer.git" }
 twox-hash = "2.1.0"
+parking_lot = "0.12.3"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/src/indexes/hnsw/mod.rs
+++ b/src/indexes/hnsw/mod.rs
@@ -131,7 +131,7 @@ impl HNSWIndex {
 
     /// Returns FileIndex (offset) corresponding to the root node.
     pub fn root_vec_offset(&self) -> FileIndex {
-        unsafe { &*self.get_root_vec() }.get_file_index()
+        unsafe { &*self.get_root_vec() }.file_index
     }
 }
 

--- a/src/models/file_persist.rs
+++ b/src/models/file_persist.rs
@@ -18,7 +18,7 @@ pub fn write_node_to_file(
     bufmans: &BufferManagerFactory<Hash>,
     level_0_bufmans: &BufferManagerFactory<Hash>,
     version: Hash,
-) -> Result<u32, WaCustomError> {
+) -> Result<u32, BufIoError> {
     let lazy_item_ref = unsafe { &*lazy_item };
     let is_level_0 = lazy_item_ref.is_level_0;
     let (bufman, bufmans) = if is_level_0 {

--- a/src/models/prob_lazy_load/lazy_item.rs
+++ b/src/models/prob_lazy_load/lazy_item.rs
@@ -2,9 +2,11 @@
 
 use std::{
     fmt::Debug,
+    ptr,
     sync::atomic::{AtomicPtr, Ordering},
 };
 
+use parking_lot::{RwLockReadGuard, RwLockWriteGuard};
 use serde::{Deserialize, Serialize};
 
 use crate::models::{
@@ -17,8 +19,6 @@ use crate::models::{
     versioning::Hash,
 };
 
-use super::lazy_item_array::ProbLazyItemArray;
-
 #[derive(Debug, Eq, PartialEq, Hash, Copy, Clone, Serialize, Deserialize)]
 pub struct FileIndex {
     pub offset: FileOffset,
@@ -26,74 +26,24 @@ pub struct FileIndex {
     pub version_id: Hash,
 }
 
-pub fn largest_power_of_4_below(x: u16) -> u8 {
-    // This function is used to calculate the largest power of 4 (4^n) such that
-    // 4^n <= x, where x represents the gap between the current version and the
-    // target version in our version control system.
-    //
-    // The system uses an exponentially spaced versioning scheme, where each
-    // checkpoint is spaced by powers of 4 (1, 4, 16, 64, etc.). This minimizes
-    // the number of intermediate versions stored, allowing efficient lookups
-    // and updates by focusing only on meaningful checkpoints.
-    //
-    // The input x should not be zero because finding a "largest power of 4 below zero"
-    // is undefined, as zero does not have any significant bits for such a calculation.
-    assert_ne!(x, 0, "x should not be zero");
-
-    // must be small enough to fit inside u8
-    let msb_position = (15 - x.leading_zeros()) as u8; // Find the most significant bit's position
-    msb_position / 2 // Return the power index of the largest 4^n ≤ x
-}
-
-#[derive(PartialEq, Debug)]
-pub struct ReadyState<T> {
-    pub data: T,
-    pub file_offset: FileOffset,
-    pub version_id: Hash,
-    pub version_number: u16,
-}
-
-// not cloneable
-#[derive(PartialEq, Debug)]
-pub enum ProbLazyItemState<T> {
-    Ready(ReadyState<T>),
-    Pending(FileIndex),
-}
-
-impl<T> ProbLazyItemState<T> {
-    pub fn get_version_number(&self) -> u16 {
-        match self {
-            Self::Pending(file_index) => file_index.version_number,
-            Self::Ready(state) => state.version_number,
-        }
-    }
-
-    pub fn get_version_id(&self) -> Hash {
-        match self {
-            Self::Pending(file_index) => file_index.version_id,
-            Self::Ready(state) => state.version_id,
-        }
-    }
-}
-
 pub struct ProbLazyItem<T> {
-    state: AtomicPtr<ProbLazyItemState<T>>,
+    data: AtomicPtr<T>,
+    pub file_index: FileIndex,
     pub is_level_0: bool,
 }
 
 impl<T: PartialEq> PartialEq for ProbLazyItem<T> {
     fn eq(&self, other: &Self) -> bool {
         self.is_level_0 == other.is_level_0
-            && unsafe {
-                *self.state.load(Ordering::Relaxed) == *other.state.load(Ordering::Relaxed)
-            }
+            && unsafe { *self.data.load(Ordering::Relaxed) == *other.data.load(Ordering::Relaxed) }
     }
 }
 
 impl<T: Debug> Debug for ProbLazyItem<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ProbLazyItem")
-            .field("state", unsafe { &*self.state.load(Ordering::Relaxed) })
+            .field("data", unsafe { &*self.data.load(Ordering::Relaxed) })
+            .field("file_index", &self.file_index)
             .field("is_level_0", &self.is_level_0)
             .finish()
     }
@@ -106,185 +56,116 @@ impl<T> ProbLazyItem<T> {
         version_id: Hash,
         version_number: u16,
         is_level_0: bool,
-        file_offset: FileOffset,
+        offset: FileOffset,
     ) -> *mut Self {
         Box::into_raw(Box::new(Self {
-            state: AtomicPtr::new(Box::into_raw(Box::new(ProbLazyItemState::Ready(
-                ReadyState {
-                    data,
-                    file_offset,
-                    version_id,
-                    version_number,
-                },
-            )))),
-            is_level_0,
-        }))
-    }
-
-    pub fn new_from_state(state: ProbLazyItemState<T>, is_level_0: bool) -> *mut Self {
-        Box::into_raw(Box::new(Self {
-            state: AtomicPtr::new(Box::into_raw(Box::new(state))),
+            data: AtomicPtr::new(Box::into_raw(Box::new(data))),
+            file_index: FileIndex {
+                offset,
+                version_number,
+                version_id,
+            },
             is_level_0,
         }))
     }
 
     pub fn new_pending(file_index: FileIndex, is_level_0: bool) -> *mut Self {
         Box::into_raw(Box::new(Self {
-            state: AtomicPtr::new(Box::into_raw(Box::new(ProbLazyItemState::Pending(
-                file_index,
-            )))),
+            data: AtomicPtr::new(ptr::null_mut()),
+            file_index,
             is_level_0,
         }))
     }
 
-    pub fn unsafe_get_state(&self) -> &ProbLazyItemState<T> {
-        // SAFETY: caller must make sure the state is not dropped by some other thread
-        unsafe { &*self.state.load(Ordering::Acquire) }
+    pub fn unsafe_get_data(&self) -> Option<&T> {
+        // SAFETY: caller must make sure the data is not dropped by some other thread
+        unsafe { self.data.load(Ordering::Acquire).as_ref() }
     }
 
-    pub fn set_state(&self, new_state: ProbLazyItemState<T>) {
-        let old_state = self
-            .state
-            .swap(Box::into_raw(Box::new(new_state)), Ordering::SeqCst);
-        unsafe {
-            // SAFETY: state must be a valid pointer
-            drop(Box::from_raw(old_state));
+    pub fn set_data(&self, new_data: T) {
+        let old_data = self
+            .data
+            .swap(Box::into_raw(Box::new(new_data)), Ordering::SeqCst);
+        if !old_data.is_null() {
+            unsafe {
+                // SAFETY: state must be a valid pointer
+                drop(Box::from_raw(old_data));
+            }
+        }
+    }
+
+    pub fn clear_data(&self) {
+        let old_data = self.data.swap(ptr::null_mut(), Ordering::SeqCst);
+        if !old_data.is_null() {
+            unsafe {
+                drop(Box::from_raw(old_data));
+            }
         }
     }
 
     pub fn is_ready(&self) -> bool {
-        unsafe {
-            matches!(
-                &*self.state.load(Ordering::Acquire),
-                ProbLazyItemState::Ready(_)
-            )
-        }
+        !self.data.load(Ordering::Acquire).is_null()
     }
 
     pub fn is_pending(&self) -> bool {
-        unsafe {
-            matches!(
-                &*self.state.load(Ordering::Acquire),
-                ProbLazyItemState::Pending(_)
-            )
-        }
+        self.data.load(Ordering::Acquire).is_null()
     }
 
     pub fn get_lazy_data<'a>(&self) -> Option<&'a T> {
-        unsafe {
-            match &*self.state.load(Ordering::Acquire) {
-                ProbLazyItemState::Pending(_) => None,
-                ProbLazyItemState::Ready(state) => Some(&state.data),
-            }
-        }
-    }
-
-    pub fn get_file_index(&self) -> FileIndex {
-        unsafe {
-            match &*self.state.load(Ordering::Acquire) {
-                ProbLazyItemState::Pending(file_index) => *file_index,
-                ProbLazyItemState::Ready(state) => FileIndex {
-                    offset: state.file_offset,
-                    version_number: state.version_number,
-                    version_id: state.version_id,
-                },
-            }
-        }
-    }
-
-    pub fn get_current_version_id(&self) -> Hash {
-        unsafe { (*self.state.load(Ordering::Acquire)).get_version_id() }
-    }
-
-    pub fn get_current_version_number(&self) -> u16 {
-        unsafe { (*self.state.load(Ordering::Acquire)).get_version_number() }
+        unsafe { self.data.load(Ordering::Acquire).as_ref() }
     }
 }
 
 impl ProbLazyItem<ProbNode> {
     pub fn try_get_data<'a>(&self, cache: &HNSWIndexCache) -> Result<&'a ProbNode, BufIoError> {
         unsafe {
-            match &*self.state.load(Ordering::Relaxed) {
-                ProbLazyItemState::Ready(state) => Ok(&state.data),
-                ProbLazyItemState::Pending(file_index) => {
-                    (*(cache.get_object(*file_index, self.is_level_0)?)).try_get_data(cache)
-                }
+            if let Some(data) = self.data.load(Ordering::Relaxed).as_ref() {
+                return Ok(data);
             }
+            (*(cache.get_object(self.file_index, self.is_level_0)?)).try_get_data(cache)
         }
     }
 
-    pub fn add_version(
+    #[allow(clippy::type_complexity)]
+    pub fn get_absolute_latest_version<'a>(
         this: *mut Self,
-        version: *mut Self,
         cache: &HNSWIndexCache,
-    ) -> Result<Result<*mut Self, *mut Self>, BufIoError> {
-        let data = unsafe { &*this }.try_get_data(cache)?;
-        let versions = &data.versions;
+    ) -> Result<(*mut Self, RwLockReadGuard<'a, (*mut Self, bool)>), BufIoError> {
+        let self_ = unsafe { &*this };
+        let guard = self_.try_get_data(cache)?.root_version.read();
+        let (root, is_root) = *guard;
+        if root.is_null() {
+            return Ok((this, guard));
+        }
+        if !is_root {
+            return Ok((root, guard));
+        }
+        drop(guard);
+        let root_ref = unsafe { &*root };
+        let guard = root_ref.try_get_data(cache)?.root_version.read();
 
-        let (_, latest_local_version_number) =
-            Self::get_latest_version_inner(this, versions, cache)?;
-
-        let result =
-            Self::add_version_inner(this, version, 0, latest_local_version_number + 1, cache)?;
-
-        Ok(result)
+        Ok((guard.0, guard))
     }
 
-    pub fn add_version_inner(
-        this: *mut Self,
-        version: *mut Self,
-        self_relative_version_number: u16,
-        target_relative_version_number: u16,
-        cache: &HNSWIndexCache,
-    ) -> Result<Result<*mut Self, *mut Self>, BufIoError> {
-        let target_diff = target_relative_version_number - self_relative_version_number;
-        if target_diff == 0 {
-            return Ok(Err(this));
-        }
-        let index = largest_power_of_4_below(target_diff);
-        let data = unsafe { &*this }.try_get_data(cache)?;
-        let versions = &data.versions;
-
-        if let Some(existing_version) = versions.get(index as usize) {
-            Self::add_version_inner(
-                existing_version,
-                version,
-                self_relative_version_number + (1 << (2 * index)),
-                target_relative_version_number,
-                cache,
-            )
-        } else {
-            debug_assert_eq!(versions.len(), index as usize);
-            versions.push(version);
-            Ok(Ok(this))
-        }
-    }
-
-    pub fn get_latest_version(
+    #[allow(clippy::type_complexity)]
+    pub fn get_absolute_latest_version_write_access<'a>(
         this: *mut Self,
         cache: &HNSWIndexCache,
-    ) -> Result<(*mut Self, u16), BufIoError> {
-        let data = unsafe { &*this }.try_get_data(cache)?;
-        let versions = &data.versions;
-
-        Self::get_latest_version_inner(this, versions, cache)
-    }
-
-    fn get_latest_version_inner<const LEN: usize>(
-        this: *mut Self,
-        versions: &ProbLazyItemArray<ProbNode, LEN>,
-        cache: &HNSWIndexCache,
-    ) -> Result<(*mut Self, u16), BufIoError> {
-        if let Some(last) = versions.last() {
-            let (latest_version, relative_local_version_number) =
-                Self::get_latest_version(last, cache)?;
-            Ok((
-                latest_version,
-                (1u16 << ((versions.len() as u8 - 1) * 2)) + relative_local_version_number,
-            ))
-        } else {
-            Ok((this, 0))
+    ) -> Result<(*mut Self, RwLockWriteGuard<'a, (*mut Self, bool)>), BufIoError> {
+        let self_ = unsafe { &*this };
+        let guard = self_.try_get_data(cache)?.root_version.write();
+        let (root, is_root) = *guard;
+        if root.is_null() {
+            return Ok((this, guard));
         }
+        if !is_root {
+            return Ok((root, guard));
+        }
+        drop(guard);
+        let root_ref = unsafe { &*root };
+        let guard = root_ref.try_get_data(cache)?.root_version.write();
+
+        Ok((guard.0, guard))
     }
 
     pub fn get_root_version(
@@ -292,41 +173,12 @@ impl ProbLazyItem<ProbNode> {
         cache: &HNSWIndexCache,
     ) -> Result<*mut Self, BufIoError> {
         let self_ = unsafe { &*this };
-        let root = self_.try_get_data(cache)?.root_version;
-        Ok(if root.is_null() { this } else { root })
-    }
-
-    pub fn get_version(
-        this: *mut Self,
-        version: u16,
-        cache: &HNSWIndexCache,
-    ) -> Result<Option<*mut Self>, BufIoError> {
-        let self_ = unsafe { &*this };
-        let version_number = self_.get_current_version_number();
-        let data = self_.try_get_data(cache)?;
-        let versions = &data.versions;
-
-        if version < version_number {
-            return Ok(None);
-        }
-
-        if version == version_number {
-            return Ok(Some(this));
-        }
-
-        let Some(mut prev) = versions.get(0) else {
-            return Ok(None);
-        };
-        let mut i = 1;
-        while let Some(next) = versions.get(i) {
-            if version < unsafe { &*next }.get_current_version_number() {
-                return Self::get_version(prev, version, cache);
-            }
-            prev = next;
-            i += 1;
-        }
-
-        Self::get_version(prev, version, cache)
+        let (root, is_root) = *self_.try_get_data(cache)?.root_version.read();
+        Ok(if root.is_null() || !is_root {
+            this
+        } else {
+            root
+        })
     }
 }
 
@@ -337,14 +189,13 @@ impl ProbLazyItem<InvertedIndexNodeData> {
         dim: u32,
     ) -> Result<&'a InvertedIndexNodeData, BufIoError> {
         unsafe {
-            match &*self.state.load(Ordering::Relaxed) {
-                ProbLazyItemState::Ready(state) => Ok(&state.data),
-                ProbLazyItemState::Pending(file_index) => {
-                    let offset = file_index.offset;
-                    (*(cache.get_data(offset, (dim % cache.data_file_parts as u32) as u8)?))
-                        .try_get_data(cache, dim)
-                }
+            if let Some(data) = self.data.load(Ordering::Relaxed).as_ref() {
+                return Ok(data);
             }
+
+            let offset = self.file_index.offset;
+            (*(cache.get_data(offset, (dim % cache.data_file_parts as u32) as u8)?))
+                .try_get_data(cache, dim)
         }
     }
 }
@@ -356,23 +207,24 @@ impl ProbLazyItem<TFIDFIndexNodeData> {
         dim: u32,
     ) -> Result<&'a TFIDFIndexNodeData, BufIoError> {
         unsafe {
-            match &*self.state.load(Ordering::Relaxed) {
-                ProbLazyItemState::Ready(state) => Ok(&state.data),
-                ProbLazyItemState::Pending(file_index) => {
-                    let offset = file_index.offset;
-                    (*(cache.get_data(offset, (dim % cache.data_file_parts as u32) as u8)?))
-                        .try_get_data(cache, dim)
-                }
+            if let Some(data) = self.data.load(Ordering::Relaxed).as_ref() {
+                return Ok(data);
             }
+
+            let offset = self.file_index.offset;
+            (*(cache.get_data(offset, (dim % cache.data_file_parts as u32) as u8)?))
+                .try_get_data(cache, dim)
         }
     }
 }
 
 impl<T> Drop for ProbLazyItem<T> {
     fn drop(&mut self) {
+        let data_ptr = self.data.load(Ordering::SeqCst);
         unsafe {
-            // SAFETY: state must be a valid pointer
-            drop(Box::from_raw(self.state.load(Ordering::SeqCst)));
+            if !data_ptr.is_null() {
+                drop(Box::from_raw(data_ptr));
+            }
         }
     }
 }

--- a/src/models/serializer/hnsw/lazy_item_array.rs
+++ b/src/models/serializer/hnsw/lazy_item_array.rs
@@ -39,7 +39,7 @@ impl<const N: usize> HNSWIndexSerialize for ProbLazyItemArray<ProbNode, N> {
                 offset,
                 version_number,
                 version_id,
-            } = item.get_file_index();
+            } = item.file_index;
 
             bufman.update_u32_with_cursor(cursor, offset.0)?;
             bufman.update_u16_with_cursor(cursor, version_number)?;

--- a/src/models/serializer/hnsw/neighbors.rs
+++ b/src/models/serializer/hnsw/neighbors.rs
@@ -8,7 +8,7 @@ use crate::models::{
     buffered_io::{BufIoError, BufferManagerFactory},
     cache_loader::HNSWIndexCache,
     prob_lazy_load::lazy_item::FileIndex,
-    prob_node::SharedNode,
+    prob_node::{ProbNode, SharedNode},
     serializer::SimpleSerialize,
     types::{FileOffset, InternalId, MetricResult},
     versioning::Hash,
@@ -33,7 +33,7 @@ impl HNSWIndexSerialize for Box<[AtomicPtr<(InternalId, SharedNode, MetricResult
         let bufman = bufmans.get(version)?;
         let start = bufman.cursor_position(cursor)?;
         debug_assert_eq!(
-            (start - 47) % (self.len() as u64 * 19 + 129),
+            (start - 47) % ProbNode::get_serialized_size(self.len()) as u64,
             0,
             "offset: {}",
             start
@@ -56,7 +56,7 @@ impl HNSWIndexSerialize for Box<[AtomicPtr<(InternalId, SharedNode, MetricResult
                 offset: node_offset,
                 version_number: node_version_number,
                 version_id: node_version_id,
-            } = node.get_file_index();
+            } = node.file_index;
             let mut buf = Vec::with_capacity(19);
             buf.extend(node_id.to_le_bytes());
             buf.extend(node_offset.0.to_le_bytes());

--- a/src/models/serializer/hnsw/tests.rs
+++ b/src/models/serializer/hnsw/tests.rs
@@ -11,11 +11,10 @@ use crate::{
         },
         prob_node::{ProbNode, SharedNode},
         types::{DistanceMetric, FileOffset, HNSWLevel, InternalId, MetricResult, NodePropValue},
-        versioning::{Hash, Version, VersionControl},
+        versioning::Hash,
     },
     storage::Storage,
 };
-use lmdb::{DatabaseFlags, Environment};
 use std::{
     collections::HashSet,
     fs::{File, OpenOptions},
@@ -40,7 +39,6 @@ impl EqualityTest for ProbNode {
     fn assert_eq(&self, other: &Self, tester: &mut EqualityTester) {
         assert_eq!(self.hnsw_level, other.hnsw_level);
         assert_eq!(self.prop_value, other.prop_value);
-        self.versions.assert_eq(&other.versions, tester);
 
         let parent = self.get_parent();
         if !parent.is_null() {
@@ -100,14 +98,7 @@ impl EqualityTest for SharedNode {
         if tester.checked.insert((*self, *other)) {
             let self_ = unsafe { &**self };
             let other = unsafe { &**other };
-            assert_eq!(
-                self_.get_current_version_id(),
-                other.get_current_version_id()
-            );
-            assert_eq!(
-                self_.get_current_version_number(),
-                other.get_current_version_number()
-            );
+            assert_eq!(self_.file_index, other.file_index);
             let self_data = self_.try_get_data(&tester.cache).unwrap();
             let other_data = other.try_get_data(&tester.cache).unwrap();
             self_data.assert_eq(other_data, tester);
@@ -399,101 +390,4 @@ fn test_prob_lazy_item_cyclic_serialization() {
     let mut tester = EqualityTester::new(cache.clone());
 
     lazy0.assert_eq(&deserialized, &mut tester);
-}
-
-fn validate_lazy_item_versions(
-    cache: &Arc<HNSWIndexCache>,
-    lazy_item: &ProbLazyItem<ProbNode>,
-    version_number: u16,
-) {
-    let data = lazy_item.try_get_data(cache).unwrap();
-    let versions = &data.versions;
-
-    for i in 0..versions.len() {
-        let version = unsafe { &*versions.get(i).unwrap() };
-        let current_version_number = version.get_current_version_number();
-
-        assert_eq!(current_version_number - version_number, 4_u16.pow(i as u32));
-        validate_lazy_item_versions(cache, version, current_version_number);
-    }
-}
-
-#[test]
-fn test_prob_lazy_item_with_versions_serialization_and_validation() {
-    let temp_dir = tempdir().unwrap();
-    let env = Arc::new(
-        Environment::new()
-            .set_max_dbs(2)
-            .set_map_size(10485760) // 10MB
-            .open(temp_dir.as_ref())
-            .unwrap(),
-    );
-    let prop_file = RwLock::new(
-        OpenOptions::new()
-            .create(true)
-            .read(true)
-            .append(true)
-            .open(temp_dir.as_ref().join("prop.data"))
-            .unwrap(),
-    );
-    let db = Arc::new(env.create_db(None, DatabaseFlags::empty()).unwrap());
-    let vcs = VersionControl::new(env, db).unwrap().0;
-
-    let v0_hash = vcs.generate_hash("main", Version::from(0)).unwrap();
-    let root = ProbLazyItem::new(
-        create_prob_node(0, &prop_file),
-        v0_hash,
-        0,
-        false,
-        FileOffset(0),
-    );
-
-    let bufmans = Arc::new(BufferManagerFactory::new(
-        temp_dir.as_ref().into(),
-        |root, ver: &Hash| root.join(format!("{}.index", **ver)),
-        ProbNode::get_serialized_size(8),
-    ));
-    let cache = get_cache(bufmans.clone(), prop_file);
-    let bufman = bufmans.get(v0_hash).unwrap();
-    let cursor = bufman.open_cursor().unwrap();
-
-    let mut nodes = Vec::new();
-    nodes.push(root);
-
-    for i in 1..=100 {
-        let (hash, _) = vcs.add_next_version("main").unwrap();
-        let next_version = ProbLazyItem::new(
-            create_prob_node(0, &cache.prop_file),
-            hash,
-            i,
-            false,
-            FileOffset(0),
-        );
-        ProbLazyItem::add_version(root, next_version, &cache)
-            .unwrap()
-            .map_err(|_| "unable to insert neighbor")
-            .unwrap();
-        nodes.push(next_version);
-    }
-
-    validate_lazy_item_versions(&cache, unsafe { &*root }, 0);
-
-    for node in nodes {
-        node.serialize(&bufmans, v0_hash, cursor).unwrap();
-    }
-    let file_index = FileIndex {
-        offset: FileOffset(0),
-        version_number: 0,
-        version_id: v0_hash,
-    };
-    bufman.close_cursor(cursor).unwrap();
-    bufmans.flush_all().unwrap();
-
-    let deserialized: SharedNode = cache.clone().load_item(file_index, false).unwrap();
-
-    validate_lazy_item_versions(&cache, unsafe { &*deserialized }, 0);
-
-    let mut tester = EqualityTester::new(cache.clone());
-
-    root.assert_eq(&deserialized, &mut tester);
 }


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->

## Explanation
This PR fixes HNSW index nodes versioning by getting rid of per node version tree and directly storing latest version pointer in the base version.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR does not contain any unnecessary/auto generated code changes.
- [x] The PR is made from a branch that's **not** called "main" and is up-to-date with "main".
- [x] The PR is **assigned** to the appropriate reviewers 

@tinkn Could you please review this when you have a moment? Thank you!
