### PR TITLE
fix(tree_map): do not store original key

### DIFF
--- a/src/models/collection.rs
+++ b/src/models/collection.rs
@@ -260,14 +260,14 @@ impl Collection {
                     }
 
                     self.internal_to_external_map
-                        .insert(transaction.id, internal_id, embedding);
+                        .insert(transaction.id, &internal_id, embedding);
                     self.external_to_internal_map
-                        .insert(transaction.id, id, internal_id);
+                        .insert(transaction.id, &id, internal_id);
 
                     if let Some(document_id) = document_id {
                         self.document_to_internals_map.push(
                             transaction.id,
-                            document_id,
+                            &document_id,
                             internal_id,
                         );
                     }

--- a/src/models/serializer/tests.rs
+++ b/src/models/serializer/tests.rs
@@ -252,11 +252,11 @@ fn test_tree_map_serialization() {
     let map = TreeMap::new(bufmans);
 
     for i in 0..1000 {
-        map.insert(0.into(), i, rng.gen_range(0..u16::MAX));
+        map.insert(0.into(), &i, rng.gen_range(0..u16::MAX));
     }
 
     // edge case
-    map.insert(0.into(), u64::MAX, rng.gen_range(0..u16::MAX));
+    map.insert(0.into(), &u64::MAX, rng.gen_range(0..u16::MAX));
 
     map.serialize(8).unwrap();
 
@@ -283,22 +283,22 @@ fn test_tree_map_incremental_serialization() {
     let map = TreeMap::new(bufmans);
 
     for i in 0..1000 {
-        map.insert(0.into(), i, rng.gen_range(0..u16::MAX));
+        map.insert(0.into(), &i, rng.gen_range(0..u16::MAX));
     }
 
     // edge case
-    map.insert(0.into(), u64::MAX, rng.gen_range(0..u16::MAX));
+    map.insert(0.into(), &u64::MAX, rng.gen_range(0..u16::MAX));
 
     map.serialize(8).unwrap();
 
     for i in 1000..2001 {
-        map.insert(0.into(), i, rng.gen_range(0..u16::MAX));
+        map.insert(0.into(), &i, rng.gen_range(0..u16::MAX));
     }
 
     map.serialize(8).unwrap();
 
     for i in 2001..3000 {
-        map.insert(0.into(), i, rng.gen_range(0..u16::MAX));
+        map.insert(0.into(), &i, rng.gen_range(0..u16::MAX));
     }
 
     map.serialize(8).unwrap();
@@ -325,22 +325,22 @@ fn test_tree_map_incremental_serialization_with_multiple_versions() {
     let map = TreeMap::new(bufmans);
 
     for i in 0..1000 {
-        map.insert(0.into(), i, rng.gen_range(0..u16::MAX));
+        map.insert(0.into(), &i, rng.gen_range(0..u16::MAX));
     }
 
     // edge case
-    map.insert(1.into(), u64::MAX, rng.gen_range(0..u16::MAX));
+    map.insert(1.into(), &u64::MAX, rng.gen_range(0..u16::MAX));
 
     map.serialize(8).unwrap();
 
     for i in 1000..2001 {
-        map.insert(2.into(), i, rng.gen_range(0..u16::MAX));
+        map.insert(2.into(), &i, rng.gen_range(0..u16::MAX));
     }
 
     map.serialize(8).unwrap();
 
     for i in 2001..3000 {
-        map.insert(3.into(), i, rng.gen_range(0..u16::MAX));
+        map.insert(3.into(), &i, rng.gen_range(0..u16::MAX));
     }
 
     map.serialize(8).unwrap();
@@ -369,19 +369,19 @@ fn test_tree_map_vec_incremental_serialization_with_multiple_versions() {
     for i in 0..1000 {
         let count: u8 = rng.gen_range(1..5);
         for _ in 0..count {
-            map.push(0.into(), i, rng.gen_range(0..u16::MAX));
+            map.push(0.into(), &i, rng.gen_range(0..u16::MAX));
         }
     }
 
     // edge case
-    map.push(1.into(), u64::MAX, rng.gen_range(0..u16::MAX));
+    map.push(1.into(), &u64::MAX, rng.gen_range(0..u16::MAX));
 
     map.serialize(8).unwrap();
 
     for i in 1000..2001 {
         let count: u8 = rng.gen_range(1..5);
         for _ in 0..count {
-            map.push(2.into(), i, rng.gen_range(0..u16::MAX));
+            map.push(2.into(), &i, rng.gen_range(0..u16::MAX));
         }
     }
 
@@ -390,7 +390,7 @@ fn test_tree_map_vec_incremental_serialization_with_multiple_versions() {
     for i in 2001..3000 {
         let count: u8 = rng.gen_range(1..5);
         for _ in 0..count {
-            map.push(3.into(), i, rng.gen_range(0..u16::MAX));
+            map.push(3.into(), &i, rng.gen_range(0..u16::MAX));
         }
     }
 

--- a/src/models/serializer/tree_map.rs
+++ b/src/models/serializer/tree_map.rs
@@ -6,15 +6,13 @@ use std::sync::{
 use crate::models::{
     atomic_array::AtomicArray,
     buffered_io::{BufIoError, BufferManagerFactory},
-    tree_map::{QuotientsMap, QuotientsMapVec, TreeMapKey, TreeMapNode, TreeMapVecNode},
+    tree_map::{QuotientsMap, QuotientsMapVec, TreeMapNode, TreeMapVecNode},
     types::FileOffset,
 };
 
 use super::{PartitionedSerialize, SimpleSerialize};
 
-impl<K: TreeMapKey + SimpleSerialize + Clone, V: SimpleSerialize> PartitionedSerialize
-    for TreeMapNode<K, V>
-{
+impl<T: SimpleSerialize> PartitionedSerialize for TreeMapNode<T> {
     fn serialize(
         &self,
         bufmans: &BufferManagerFactory<u8>,
@@ -127,9 +125,7 @@ impl<K: TreeMapKey + SimpleSerialize + Clone, V: SimpleSerialize> PartitionedSer
     }
 }
 
-impl<K: TreeMapKey + SimpleSerialize + Clone, V: SimpleSerialize> PartitionedSerialize
-    for TreeMapVecNode<K, V>
-{
+impl<T: SimpleSerialize> PartitionedSerialize for TreeMapVecNode<T> {
     fn serialize(
         &self,
         bufmans: &BufferManagerFactory<u8>,


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->

## Explanation
This PR modifies the `TreeMap` to not store the original key.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR does not contain any unnecessary/auto generated code changes.
- [x] The PR is made from a branch that's **not** called "main" and is up-to-date with "main".
- [x] The PR is **assigned** to the appropriate reviewers 

@tinkn Could you please review this when you have a moment? Thank you!
