### PR TITLE
Fix max_level calculation for pseudo nodes during indexing

### DIFF
--- a/src/vector_store.rs
+++ b/src/vector_store.rs
@@ -497,10 +497,10 @@ fn preprocess_embedding(
         let num_levels = hnsw_index.levels_prob.len() - 1;
         let plp = pseudo_level_probs(num_levels as u8, replicas.len() as u16);
         let mut embeddings: Vec<IndexableEmbedding> = vec![];
-        let mut is_first_overrideen = false;
+        let mut is_first_overridden = false;
         for (replica_id, prop_metadata) in replicas.into_iter().enumerate() {
-            let overridden_level_probs = if !is_first_overrideen {
-                is_first_overrideen = true;
+            let overridden_level_probs = if !is_first_overridden {
+                is_first_overridden = true;
                 plp.iter()
                     .map(|(_, lev)| (0.0, *lev))
                     .collect::<Vec<(f64, u8)>>()
@@ -585,8 +585,10 @@ pub fn index_embeddings(
             })
             .collect::<Vec<IndexableEmbedding>>();
         for emb in embeddings {
-            let max_level =
-                get_max_insert_level(rand::random::<f32>().into(), &hnsw_index.levels_prob);
+            let max_level = match emb.overridden_level_probs {
+                Some(lp) => get_max_insert_level(rand::random::<f32>().into(), &lp),
+                None => get_max_insert_level(rand::random::<f32>().into(), &hnsw_index.levels_prob),
+            };
             // Start from root at highest level
             let root_entry = hnsw_index.get_root_vec();
             let highest_level = HNSWLevel(hnsw_params_guard.num_layers);


### PR DESCRIPTION
It seems this code was mistakenly removed during a recent refactor (commit - 31e2db3504ceece184ddac103b3cab831b12dc7e).

Additionally, this commit fixes a typo in a variable name 'overrideen' -> 'overridden'.

## Explanation
If the vector store has metadata schema, the max_level is overridden for pseudo nodes. Looks like this code was mistakenly removed in a recent refactor. This commit adds it back.

Creating a separate PR so it's easier to review. 

Fixes #

## Essential Checklist
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR does not contain any unnecessary/auto generated code changes.
- [x] The PR is made from a branch that's **not** called "main" and is up-to-date with "main".
- [x] The PR is **assigned** to the appropriate reviewers 

@a-rustacean @tinkn Could you please review this when you have a moment? Thank you!
