### PR TITLE
feat(install): add shell detection for PATH and COSDATA_HOME setup

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-REPO="cosdata/cosdata"  # Replace with your actual repo
+REPO="cosdata/cosdata" # Replace with your actual repo
 TMP_DIR=$(mktemp -d)
 ARTIFACT_NAME="cosdata"
 
 echo "Fetching latest release..."
 
-LATEST_RELEASE=$(curl -s "https://api.github.com/repos/$REPO/releases" | 
-  grep '"tag_name":' |  
-  sed -E 's/.*"([^"]+)".*/\1/' |  
-  sort -V |  
+LATEST_RELEASE=$(curl -s "https://api.github.com/repos/$REPO/releases" |
+  grep '"tag_name":' |
+  sed -E 's/.*"([^"]+)".*/\1/' |
+  sort -V |
   tail -n 1)
 
 if [ -z "$LATEST_RELEASE" ]; then
-    echo "Error: Could not fetch latest release."
-    exit 1
+  echo "Error: Could not fetch latest release."
+  exit 1
 fi
 
 INSTALL_DIR="$HOME/cosdata-$LATEST_RELEASE"
@@ -34,20 +34,27 @@ curl -sL "https://github.com/$REPO/releases/download/$LATEST_RELEASE/config.toml
 echo "Setting executable permissions..."
 chmod +x "$BIN_DIR/$ARTIFACT_NAME"
 
-# Add the versioned install directory to PATH
-if ! echo "$PATH" | grep -q "$BIN_DIR"; then
-    echo "Adding $BIN_DIR to PATH..."
-    echo "export PATH=\"$BIN_DIR:\$PATH\"" >> "$HOME/.bashrc"
-    echo "export PATH=\"$BIN_DIR:\$PATH\"" >> "$HOME/.zshrc"
-fi
+# Detect current shell
+CURRENT_SHELL=$(basename "$SHELL")
+case "$CURRENT_SHELL" in
+bash) CONFIG_FILE="$HOME/.bashrc" ;;
+zsh) CONFIG_FILE="$HOME/.zshrc" ;;
+fish) CONFIG_FILE="$HOME/.config/fish/config.fish" ;;
+*)
+  echo "Unsupported shell: $CURRENT_SHELL. Please manually update your shell config."
+  CONFIG_FILE=""
+  ;;
+esac
 
-# Set COSDATA_HOME for the installed version
-echo "export COSDATA_HOME=\"$INSTALL_DIR\"" >> "$HOME/.bashrc"
-echo "export COSDATA_HOME=\"$INSTALL_DIR\"" >> "$HOME/.zshrc"
+# Update PATH and COSDATA_HOME only if shell is recognized
+if [ -n "$CONFIG_FILE" ]; then
+  echo "export PATH=\"$BIN_DIR:\$PATH\"" >>"$CONFIG_FILE"
+  echo "export COSDATA_HOME=\"$INSTALL_DIR\"" >>"$CONFIG_FILE"
+fi
 
 # Create a wrapper script to prompt for the admin key on first run
 LAUNCH_SCRIPT="$BIN_DIR/start-cosdata"
-cat <<EOF > "$LAUNCH_SCRIPT"
+cat <<EOF >"$LAUNCH_SCRIPT"
 #!/bin/bash
 read -s -p "Enter Admin Key: " COSDATA_ADMIN_KEY
 echo ""
@@ -57,5 +64,11 @@ EOF
 
 chmod +x "$LAUNCH_SCRIPT"
 
-echo "Installation complete! Restart your terminal or run 'source ~/.bashrc'."
+echo "Installation complete!"
+if [ -n "$CONFIG_FILE" ]; then
+  echo "Restart your terminal or run: source $CONFIG_FILE"
+else
+  echo "Please manually add $BIN_DIR to your PATH and set COSDATA_HOME."
+fi
+
 echo "Run 'start-cosdata' to start Cosdata."


### PR DESCRIPTION
## Explanation

This is a feature PR as mentioned in https://github.com/cosdata/cosdata/issues/301 and improves shell configuration portability by automatically detecting the user's current shell (`bash`, `zsh`, or `fish`) and appending the necessary `export PATH` and `COSDATA_HOME` lines to the correct shell configuration file (`~/.bashrc`, `~/.zshrc`, or `~/.config/fish/config.fish`). This ensures seamless setup across different environments and simplifies user instructions.

## Essential Checklist
- [x] The PR title and explanation each start with Feature https://github.com/cosdata/cosdata/issues/301
- [x] The PR does not contain any unnecessary/auto generated code changes.
- [x] The PR is made from a branch that's **not** called "main" and is up-to-date with "main".
- [x] The PR is **assigned** to the appropriate reviewers

@anandwana001  Could you please review this when you have a moment? Thank you!
