### PR TITLE
feat(api): OpenAPI 3.0 specification generation using utoipa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /target
 /versions
-Cargo.lock
 rr
 /xdb
 flamegraph.svg
@@ -18,4 +17,6 @@ _mdb
 venv
 /collections/
 .idea/
-/datasets
+datasets/
+data/
+.vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,6 +832,7 @@ dependencies = [
  "tonic-build",
  "tonic-reflection",
  "twox-hash",
+ "utoipa",
 ]
 
 [[package]]
@@ -1638,6 +1639,7 @@ checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+ "serde",
 ]
 
 [[package]]
@@ -3016,6 +3018,30 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435c6f69ef38c9017b4b4eea965dfb91e71e53d869e896db40d1cf2441dd75c0"
+dependencies = [
+ "indexmap 2.7.1",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77d306bc75294fd52f3e99b13ece67c02c1a2789190a6f31d32f736624326f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.98",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ snowball-stemmer = { git = "https://github.com/cosdata/snowball-stemmer.git" }
 twox-hash = "2.1.0"
 parking_lot = "0.12.3"
 crossbeam = "0.8.4"
+utoipa = {version = "5.3.1", features = ["actix_extras"] }
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/src/api/auth/controller.rs
+++ b/src/api/auth/controller.rs
@@ -5,8 +5,21 @@ use actix_web::{
 
 use crate::app_context::AppContext;
 
-use super::{dtos::CreateSessionDTO, service};
+use super::{dtos::{CreateSessionDTO, Session}, service};
 
+/// Create a new user session (login)
+#[utoipa::path(
+    post,
+    path = "/auth/create-session",
+    request_body = CreateSessionDTO,
+    responses(
+        (status = 200, description = "Session created successfully", body = Session),
+        (status = 400, description = "Wrong credentials"),
+        (status = 401, description = "Invalid authentication token"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "auth"
+)]
 pub(crate) async fn create_session(
     web::Json(create_session_dto): web::Json<CreateSessionDTO>,
     ctx: web::Data<AppContext>,

--- a/src/api/auth/dtos.rs
+++ b/src/api/auth/dtos.rs
@@ -1,23 +1,31 @@
 use actix_web::{dev::Payload, FromRequest, HttpMessage, HttpRequest};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use super::error::AuthError;
 use futures_util::future::{err, ok, Ready};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+/// DTO for creating a user session (login)
+#[derive(Debug, Serialize, Deserialize, PartialEq, ToSchema)]
 pub(crate) struct CreateSessionDTO {
+    /// Username for authentication
     pub username: String,
+    /// Password for authentication
     pub password: String,
 }
 
-#[derive(Serialize)]
+/// Session response after successful authentication
+#[derive(Serialize, ToSchema)]
 pub(crate) struct Session {
+    /// Authentication token for subsequent requests
     pub access_token: String,
+    /// Timestamp when the session was created
     pub created_at: u64,
+    /// Timestamp when the session will expire
     pub expires_at: u64,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 // a structure for holding claims data used in JWT tokens
 // resembles payload in NodeJS world
 pub struct Claims {

--- a/src/api/auth/mod.rs
+++ b/src/api/auth/mod.rs
@@ -1,7 +1,7 @@
 use actix_web::{web, Scope};
 pub(crate) mod authentication_middleware;
-mod controller;
-mod dtos;
+pub mod controller;
+pub mod dtos;
 mod error;
 mod service;
 

--- a/src/api/docs.rs
+++ b/src/api/docs.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, HttpResponse, Scope};
-use crate::api::openapi::{AuthApiDoc, CollectionsApiDoc, CombinedApiDoc, IndexesApiDoc, SearchApiDoc, VectorsApiDoc, VersionsApiDoc};
+use crate::api::openapi::{AuthApiDoc, CollectionsApiDoc, CombinedApiDoc, IndexesApiDoc, SearchApiDoc, TransactionsApiDoc, VectorsApiDoc, VersionsApiDoc};
 use utoipa::OpenApi;
 
 pub(crate) fn api_docs_module() -> Scope {
@@ -9,6 +9,7 @@ pub(crate) fn api_docs_module() -> Scope {
         .route("/collections/openapi.json", web::get().to(collections_openapi_json))
         .route("/indexes/openapi.json", web::get().to(indexes_openapi_json))
         .route("/search/openapi.json", web::get().to(search_openapi_json))
+        .route("/transactions/openapi.json", web::get().to(transactions_openapi_json))
         .route("/vectors/openapi.json", web::get().to(vectors_openapi_json))
         .route("/versions/openapi.json", web::get().to(versions_openapi_json))
 }
@@ -31,6 +32,10 @@ async fn indexes_openapi_json() -> HttpResponse {
 
 async fn search_openapi_json() -> HttpResponse {
     HttpResponse::Ok().json(SearchApiDoc::openapi())
+}
+
+async fn transactions_openapi_json() -> HttpResponse {
+    HttpResponse::Ok().json(TransactionsApiDoc::openapi())
 }
 
 async fn vectors_openapi_json() -> HttpResponse {

--- a/src/api/docs.rs
+++ b/src/api/docs.rs
@@ -1,0 +1,12 @@
+use actix_web::{web, HttpResponse, Scope};
+use crate::api::openapi::AuthApiDoc;
+use utoipa::OpenApi;
+
+pub(crate) fn api_docs_module() -> Scope {
+    web::scope("/api-docs")
+        .route("/openapi.json", web::get().to(openapi_json))
+}
+
+async fn openapi_json() -> HttpResponse {
+    HttpResponse::Ok().json(AuthApiDoc::openapi())
+}

--- a/src/api/docs.rs
+++ b/src/api/docs.rs
@@ -1,12 +1,22 @@
 use actix_web::{web, HttpResponse, Scope};
-use crate::api::openapi::AuthApiDoc;
+use crate::api::openapi::{AuthApiDoc, CollectionsApiDoc, CombinedApiDoc};
 use utoipa::OpenApi;
 
 pub(crate) fn api_docs_module() -> Scope {
     web::scope("/api-docs")
         .route("/openapi.json", web::get().to(openapi_json))
+        .route("/auth/openapi.json", web::get().to(auth_openapi_json))
+        .route("/collections/openapi.json", web::get().to(collections_openapi_json))
 }
 
 async fn openapi_json() -> HttpResponse {
+    HttpResponse::Ok().json(CombinedApiDoc::openapi())
+}
+
+async fn auth_openapi_json() -> HttpResponse {
     HttpResponse::Ok().json(AuthApiDoc::openapi())
+}
+
+async fn collections_openapi_json() -> HttpResponse {
+    HttpResponse::Ok().json(CollectionsApiDoc::openapi())
 }

--- a/src/api/docs.rs
+++ b/src/api/docs.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, HttpResponse, Scope};
-use crate::api::openapi::{AuthApiDoc, CollectionsApiDoc, CombinedApiDoc, IndexesApiDoc, SearchApiDoc, TransactionsApiDoc, VectorsApiDoc, VersionsApiDoc};
+use crate::api::openapi::{AuthApiDoc, CollectionsApiDoc, CombinedApiDoc, IndexesApiDoc, SearchApiDoc, SyncTransactionsApiDoc, TransactionsApiDoc, VectorsApiDoc, VersionsApiDoc};
 use utoipa::OpenApi;
 
 pub(crate) fn api_docs_module() -> Scope {
@@ -12,6 +12,7 @@ pub(crate) fn api_docs_module() -> Scope {
         .route("/transactions/openapi.json", web::get().to(transactions_openapi_json))
         .route("/vectors/openapi.json", web::get().to(vectors_openapi_json))
         .route("/versions/openapi.json", web::get().to(versions_openapi_json))
+        .route("/sync_transactions/openapi.json", web::get().to(sync_transactions_openapi_json))
 }
 
 async fn openapi_json() -> HttpResponse {
@@ -44,4 +45,8 @@ async fn vectors_openapi_json() -> HttpResponse {
 
 async fn versions_openapi_json() -> HttpResponse {
     HttpResponse::Ok().json(VersionsApiDoc::openapi())
+}
+
+async fn sync_transactions_openapi_json() -> HttpResponse {
+    HttpResponse::Ok().json(SyncTransactionsApiDoc::openapi())
 }

--- a/src/api/docs.rs
+++ b/src/api/docs.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, HttpResponse, Scope};
-use crate::api::openapi::{AuthApiDoc, CollectionsApiDoc, CombinedApiDoc, IndexesApiDoc};
+use crate::api::openapi::{AuthApiDoc, CollectionsApiDoc, CombinedApiDoc, IndexesApiDoc, SearchApiDoc};
 use utoipa::OpenApi;
 
 pub(crate) fn api_docs_module() -> Scope {
@@ -8,6 +8,7 @@ pub(crate) fn api_docs_module() -> Scope {
         .route("/auth/openapi.json", web::get().to(auth_openapi_json))
         .route("/collections/openapi.json", web::get().to(collections_openapi_json))
         .route("/indexes/openapi.json", web::get().to(indexes_openapi_json))
+        .route("/search/openapi.json", web::get().to(search_openapi_json))
 }
 
 async fn openapi_json() -> HttpResponse {
@@ -24,4 +25,8 @@ async fn collections_openapi_json() -> HttpResponse {
 
 async fn indexes_openapi_json() -> HttpResponse {
     HttpResponse::Ok().json(IndexesApiDoc::openapi())
+}
+
+async fn search_openapi_json() -> HttpResponse {
+    HttpResponse::Ok().json(SearchApiDoc::openapi())
 }

--- a/src/api/docs.rs
+++ b/src/api/docs.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, HttpResponse, Scope};
-use crate::api::openapi::{AuthApiDoc, CollectionsApiDoc, CombinedApiDoc};
+use crate::api::openapi::{AuthApiDoc, CollectionsApiDoc, CombinedApiDoc, IndexesApiDoc};
 use utoipa::OpenApi;
 
 pub(crate) fn api_docs_module() -> Scope {
@@ -7,6 +7,7 @@ pub(crate) fn api_docs_module() -> Scope {
         .route("/openapi.json", web::get().to(openapi_json))
         .route("/auth/openapi.json", web::get().to(auth_openapi_json))
         .route("/collections/openapi.json", web::get().to(collections_openapi_json))
+        .route("/indexes/openapi.json", web::get().to(indexes_openapi_json))
 }
 
 async fn openapi_json() -> HttpResponse {
@@ -19,4 +20,8 @@ async fn auth_openapi_json() -> HttpResponse {
 
 async fn collections_openapi_json() -> HttpResponse {
     HttpResponse::Ok().json(CollectionsApiDoc::openapi())
+}
+
+async fn indexes_openapi_json() -> HttpResponse {
+    HttpResponse::Ok().json(IndexesApiDoc::openapi())
 }

--- a/src/api/docs.rs
+++ b/src/api/docs.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, HttpResponse, Scope};
-use crate::api::openapi::{AuthApiDoc, CollectionsApiDoc, CombinedApiDoc, IndexesApiDoc, SearchApiDoc};
+use crate::api::openapi::{AuthApiDoc, CollectionsApiDoc, CombinedApiDoc, IndexesApiDoc, SearchApiDoc, VectorsApiDoc};
 use utoipa::OpenApi;
 
 pub(crate) fn api_docs_module() -> Scope {
@@ -9,6 +9,7 @@ pub(crate) fn api_docs_module() -> Scope {
         .route("/collections/openapi.json", web::get().to(collections_openapi_json))
         .route("/indexes/openapi.json", web::get().to(indexes_openapi_json))
         .route("/search/openapi.json", web::get().to(search_openapi_json))
+        .route("/vectors/openapi.json", web::get().to(vectors_openapi_json))
 }
 
 async fn openapi_json() -> HttpResponse {
@@ -29,4 +30,8 @@ async fn indexes_openapi_json() -> HttpResponse {
 
 async fn search_openapi_json() -> HttpResponse {
     HttpResponse::Ok().json(SearchApiDoc::openapi())
+}
+
+async fn vectors_openapi_json() -> HttpResponse {
+    HttpResponse::Ok().json(VectorsApiDoc::openapi())
 }

--- a/src/api/docs.rs
+++ b/src/api/docs.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, HttpResponse, Scope};
-use crate::api::openapi::{AuthApiDoc, CollectionsApiDoc, CombinedApiDoc, IndexesApiDoc, SearchApiDoc, VectorsApiDoc};
+use crate::api::openapi::{AuthApiDoc, CollectionsApiDoc, CombinedApiDoc, IndexesApiDoc, SearchApiDoc, VectorsApiDoc, VersionsApiDoc};
 use utoipa::OpenApi;
 
 pub(crate) fn api_docs_module() -> Scope {
@@ -10,6 +10,7 @@ pub(crate) fn api_docs_module() -> Scope {
         .route("/indexes/openapi.json", web::get().to(indexes_openapi_json))
         .route("/search/openapi.json", web::get().to(search_openapi_json))
         .route("/vectors/openapi.json", web::get().to(vectors_openapi_json))
+        .route("/versions/openapi.json", web::get().to(versions_openapi_json))
 }
 
 async fn openapi_json() -> HttpResponse {
@@ -34,4 +35,8 @@ async fn search_openapi_json() -> HttpResponse {
 
 async fn vectors_openapi_json() -> HttpResponse {
     HttpResponse::Ok().json(VectorsApiDoc::openapi())
+}
+
+async fn versions_openapi_json() -> HttpResponse {
+    HttpResponse::Ok().json(VersionsApiDoc::openapi())
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,2 +1,4 @@
 pub(crate) mod auth;
+pub(crate) mod docs;
+pub(crate) mod openapi;
 pub(crate) mod vectordb;

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -215,6 +215,24 @@ pub struct TransactionsApiDoc;
 )]
 pub struct VectorsApiDoc;
 
+/// API documentation for sync transaction endpoints
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        crate::api::vectordb::sync_transaction::controller::upsert,
+        crate::api::vectordb::sync_transaction::controller::delete_vector_by_id
+    ),
+    components(
+        schemas(
+            crate::api::vectordb::transactions::dtos::UpsertDto
+        )
+    ),
+    tags(
+        (name = "sync_transactions", description = "Synchronous transaction endpoints")
+    )
+)]
+pub struct SyncTransactionsApiDoc;
+
 /// Combined API documentation
 #[derive(OpenApi)]
 #[openapi(
@@ -254,7 +272,9 @@ pub struct VectorsApiDoc;
         crate::api::vectordb::transactions::controller::create_vector_in_transaction,
         crate::api::vectordb::transactions::controller::delete_vector_by_id,
         crate::api::vectordb::transactions::controller::abort_transaction,
-        crate::api::vectordb::transactions::controller::upsert
+        crate::api::vectordb::transactions::controller::upsert,
+        crate::api::vectordb::sync_transaction::controller::upsert,
+        crate::api::vectordb::sync_transaction::controller::delete_vector_by_id
     ),
     components(
         schemas(
@@ -328,7 +348,8 @@ pub struct VectorsApiDoc;
         (name = "search", description = "Vector search endpoints"),
         (name = "vectors", description = "Vector management endpoints"),
         (name = "versions", description = "Version management endpoints"),
-        (name = "transactions", description = "Transaction management endpoints")
+        (name = "transactions", description = "Transaction management endpoints"),
+        (name = "sync_transactions", description = "Synchronous transaction endpoints")
     )
 )]
 pub struct CombinedApiDoc;
@@ -370,6 +391,12 @@ impl utoipa::Modify for TransactionsApiDoc {
 }
 
 impl utoipa::Modify for VersionsApiDoc {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        openapi.info = api_info().build();
+    }
+}
+
+impl utoipa::Modify for SyncTransactionsApiDoc {
     fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
         openapi.info = api_info().build();
     }

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -111,6 +111,40 @@ pub struct CollectionsApiDoc;
 )]
 pub struct IndexesApiDoc;
 
+/// API documentation for search endpoints
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        crate::api::vectordb::search::controller::dense_search,
+        crate::api::vectordb::search::controller::batch_dense_search,
+        crate::api::vectordb::search::controller::sparse_search,
+        crate::api::vectordb::search::controller::batch_sparse_search,
+        crate::api::vectordb::search::controller::hybrid_search,
+        crate::api::vectordb::search::controller::tf_idf_search,
+        crate::api::vectordb::search::controller::batch_tf_idf_search
+    ),
+    components(
+        schemas(
+            crate::api::vectordb::search::dtos::DenseSearchRequestDto,
+            crate::api::vectordb::search::dtos::BatchDenseSearchRequestDto,
+            crate::api::vectordb::search::dtos::BatchDenseSearchRequestQueryDto,
+            crate::api::vectordb::search::dtos::SparseSearchRequestDto,
+            crate::api::vectordb::search::dtos::BatchSparseSearchRequestDto,
+            crate::api::vectordb::search::dtos::HybridSearchRequestDto,
+            crate::api::vectordb::search::dtos::HybridSearchQuery,
+            crate::api::vectordb::search::dtos::FindSimilarTFIDFDocumentDto,
+            crate::api::vectordb::search::dtos::BatchSearchTFIDFDocumentsDto,
+            crate::api::vectordb::search::dtos::SearchResultItemDto,
+            crate::api::vectordb::search::dtos::SearchResponseDto,
+            crate::api::vectordb::search::dtos::BatchSearchResponseDto
+        )
+    ),
+    tags(
+        (name = "search", description = "Vector search endpoints")
+    )
+)]
+pub struct SearchApiDoc;
+
 /// Combined API documentation
 #[derive(OpenApi)]
 #[openapi(
@@ -129,7 +163,14 @@ pub struct IndexesApiDoc;
         crate::api::vectordb::indexes::controller::create_sparse_index,
         crate::api::vectordb::indexes::controller::create_tf_idf_index,
         crate::api::vectordb::indexes::controller::get_index,
-        crate::api::vectordb::indexes::controller::delete_index
+        crate::api::vectordb::indexes::controller::delete_index,
+        crate::api::vectordb::search::controller::dense_search,
+        crate::api::vectordb::search::controller::batch_dense_search,
+        crate::api::vectordb::search::controller::sparse_search,
+        crate::api::vectordb::search::controller::batch_sparse_search,
+        crate::api::vectordb::search::controller::hybrid_search,
+        crate::api::vectordb::search::controller::tf_idf_search,
+        crate::api::vectordb::search::controller::batch_tf_idf_search
     ),
     components(
         schemas(
@@ -170,13 +211,26 @@ pub struct IndexesApiDoc;
             crate::api::vectordb::indexes::dtos::TfIdfIndexInfo,
             crate::api::vectordb::indexes::dtos::QuantizationInfo,
             crate::api::vectordb::indexes::dtos::RangeInfo,
-            crate::api::vectordb::indexes::dtos::HnswParamsInfo
+            crate::api::vectordb::indexes::dtos::HnswParamsInfo,
+            crate::api::vectordb::search::dtos::DenseSearchRequestDto,
+            crate::api::vectordb::search::dtos::BatchDenseSearchRequestDto,
+            crate::api::vectordb::search::dtos::BatchDenseSearchRequestQueryDto,
+            crate::api::vectordb::search::dtos::SparseSearchRequestDto,
+            crate::api::vectordb::search::dtos::BatchSparseSearchRequestDto,
+            crate::api::vectordb::search::dtos::HybridSearchRequestDto,
+            crate::api::vectordb::search::dtos::HybridSearchQuery,
+            crate::api::vectordb::search::dtos::FindSimilarTFIDFDocumentDto,
+            crate::api::vectordb::search::dtos::BatchSearchTFIDFDocumentsDto,
+            crate::api::vectordb::search::dtos::SearchResultItemDto,
+            crate::api::vectordb::search::dtos::SearchResponseDto,
+            crate::api::vectordb::search::dtos::BatchSearchResponseDto
         )
     ),
     tags(
         (name = "auth", description = "Authentication endpoints"),
         (name = "collections", description = "Collection management endpoints"),
-        (name = "indexes", description = "Index management endpoints")
+        (name = "indexes", description = "Index management endpoints"),
+        (name = "search", description = "Vector search endpoints")
     )
 )]
 pub struct CombinedApiDoc;
@@ -194,6 +248,12 @@ impl utoipa::Modify for CollectionsApiDoc {
 }
 
 impl utoipa::Modify for IndexesApiDoc {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        openapi.info = api_info().build();
+    }
+}
+
+impl utoipa::Modify for SearchApiDoc {
     fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
         openapi.info = api_info().build();
     }

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -145,6 +145,28 @@ pub struct IndexesApiDoc;
 )]
 pub struct SearchApiDoc;
 
+/// API documentation for vector management endpoints
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        crate::api::vectordb::vectors::controller::query_vectors,
+        crate::api::vectordb::vectors::controller::get_vector_by_id,
+        crate::api::vectordb::vectors::controller::check_vector_existence,
+        crate::api::vectordb::vectors::controller::fetch_vector_neighbors
+    ),
+    components(
+        schemas(
+            crate::api::vectordb::vectors::dtos::VectorsQueryDto,
+            crate::api::vectordb::vectors::dtos::CreateVectorDto,
+            crate::api::vectordb::vectors::dtos::SimilarVector
+        )
+    ),
+    tags(
+        (name = "vectors", description = "Vector management endpoints")
+    )
+)]
+pub struct VectorsApiDoc;
+
 /// Combined API documentation
 #[derive(OpenApi)]
 #[openapi(
@@ -170,7 +192,11 @@ pub struct SearchApiDoc;
         crate::api::vectordb::search::controller::batch_sparse_search,
         crate::api::vectordb::search::controller::hybrid_search,
         crate::api::vectordb::search::controller::tf_idf_search,
-        crate::api::vectordb::search::controller::batch_tf_idf_search
+        crate::api::vectordb::search::controller::batch_tf_idf_search,
+        crate::api::vectordb::vectors::controller::query_vectors,
+        crate::api::vectordb::vectors::controller::get_vector_by_id,
+        crate::api::vectordb::vectors::controller::check_vector_existence,
+        crate::api::vectordb::vectors::controller::fetch_vector_neighbors
     ),
     components(
         schemas(
@@ -223,14 +249,18 @@ pub struct SearchApiDoc;
             crate::api::vectordb::search::dtos::BatchSearchTFIDFDocumentsDto,
             crate::api::vectordb::search::dtos::SearchResultItemDto,
             crate::api::vectordb::search::dtos::SearchResponseDto,
-            crate::api::vectordb::search::dtos::BatchSearchResponseDto
+            crate::api::vectordb::search::dtos::BatchSearchResponseDto,
+            crate::api::vectordb::vectors::dtos::VectorsQueryDto,
+            crate::api::vectordb::vectors::dtos::CreateVectorDto,
+            crate::api::vectordb::vectors::dtos::SimilarVector
         )
     ),
     tags(
         (name = "auth", description = "Authentication endpoints"),
         (name = "collections", description = "Collection management endpoints"),
         (name = "indexes", description = "Index management endpoints"),
-        (name = "search", description = "Vector search endpoints")
+        (name = "search", description = "Vector search endpoints"),
+        (name = "vectors", description = "Vector management endpoints")
     )
 )]
 pub struct CombinedApiDoc;
@@ -254,6 +284,12 @@ impl utoipa::Modify for IndexesApiDoc {
 }
 
 impl utoipa::Modify for SearchApiDoc {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        openapi.info = api_info().build();
+    }
+}
+
+impl utoipa::Modify for VectorsApiDoc {
     fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
         openapi.info = api_info().build();
     }

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -1,0 +1,29 @@
+use utoipa::OpenApi;
+
+/// API documentation for authentication endpoints
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        crate::api::auth::controller::create_session
+    ),
+    components(
+        schemas(
+            crate::api::auth::dtos::CreateSessionDTO,
+            crate::api::auth::dtos::Session,
+            crate::api::auth::dtos::Claims
+        )
+    ),
+    tags(
+        (name = "auth", description = "Authentication endpoints")
+    ),
+    info(
+        title = "Cosdata API",
+        version = env!("CARGO_PKG_VERSION"),
+        description = "Cosdata Vector Database API",
+        license(
+            name = "Apache 2.0",
+            url = "https://www.apache.org/licenses/LICENSE-2.0"
+        )
+    )
+)]
+pub struct AuthApiDoc;

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -19,7 +19,7 @@ use utoipa::OpenApi;
     info(
         title = "Cosdata API",
         version = env!("CARGO_PKG_VERSION"),
-        description = "Cosdata Vector Database API",
+        description = "Cosdata Vector Database API - Authentication",
         license(
             name = "Apache 2.0",
             url = "https://www.apache.org/licenses/LICENSE-2.0"
@@ -27,3 +27,117 @@ use utoipa::OpenApi;
     )
 )]
 pub struct AuthApiDoc;
+
+/// API documentation for collection management endpoints
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        crate::api::vectordb::collections::controller::create_collection,
+        crate::api::vectordb::collections::controller::get_collections,
+        crate::api::vectordb::collections::controller::get_collection_by_id,
+        crate::api::vectordb::collections::controller::get_collection_indexing_status,
+        crate::api::vectordb::collections::controller::delete_collection_by_id,
+        crate::api::vectordb::collections::controller::load_collection,
+        crate::api::vectordb::collections::controller::unload_collection,
+        crate::api::vectordb::collections::controller::get_loaded_collections,
+        crate::api::vectordb::collections::controller::list_collections
+    ),
+    components(
+        schemas(
+            crate::api::vectordb::collections::dtos::CreateCollectionDto,
+            crate::api::vectordb::collections::dtos::CreateCollectionDtoResponse,
+            crate::api::vectordb::collections::dtos::GetCollectionsDto,
+            crate::api::vectordb::collections::dtos::GetCollectionsResponseDto,
+            crate::api::vectordb::collections::dtos::ListCollectionsResponseDto,
+            crate::api::vectordb::collections::dtos::CollectionSummaryDto,
+            crate::api::vectordb::collections::dtos::MetadataField,
+            crate::api::vectordb::collections::dtos::MetadataSchemaParam,
+            crate::api::vectordb::collections::dtos::SupportedCondition,
+            crate::api::vectordb::collections::dtos::ConditionOp,
+            crate::models::collection::CollectionConfig,
+            crate::models::collection::DenseVectorOptions,
+            crate::models::collection::SparseVectorOptions,
+            crate::models::collection::TFIDFOptions,
+            CollectionIndexingStatusResponse
+        )
+    ),
+    tags(
+        (name = "collections", description = "Collection management endpoints")
+    ),
+    info(
+        title = "Cosdata API",
+        version = env!("CARGO_PKG_VERSION"),
+        description = "Cosdata Vector Database API - Collection Management",
+        license(
+            name = "Apache 2.0",
+            url = "https://www.apache.org/licenses/LICENSE-2.0"
+        )
+    )
+)]
+pub struct CollectionsApiDoc;
+
+/// Combined API documentation
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        crate::api::auth::controller::create_session,
+        crate::api::vectordb::collections::controller::create_collection,
+        crate::api::vectordb::collections::controller::get_collections,
+        crate::api::vectordb::collections::controller::get_collection_by_id,
+        crate::api::vectordb::collections::controller::get_collection_indexing_status,
+        crate::api::vectordb::collections::controller::delete_collection_by_id,
+        crate::api::vectordb::collections::controller::load_collection,
+        crate::api::vectordb::collections::controller::unload_collection,
+        crate::api::vectordb::collections::controller::get_loaded_collections,
+        crate::api::vectordb::collections::controller::list_collections
+    ),
+    components(
+        schemas(
+            crate::api::auth::dtos::CreateSessionDTO,
+            crate::api::auth::dtos::Session,
+            crate::api::auth::dtos::Claims,
+            crate::api::vectordb::collections::dtos::CreateCollectionDto,
+            crate::api::vectordb::collections::dtos::CreateCollectionDtoResponse,
+            crate::api::vectordb::collections::dtos::GetCollectionsDto,
+            crate::api::vectordb::collections::dtos::GetCollectionsResponseDto,
+            crate::api::vectordb::collections::dtos::ListCollectionsResponseDto,
+            crate::api::vectordb::collections::dtos::CollectionSummaryDto,
+            crate::api::vectordb::collections::dtos::MetadataField,
+            crate::api::vectordb::collections::dtos::MetadataSchemaParam,
+            crate::api::vectordb::collections::dtos::SupportedCondition,
+            crate::api::vectordb::collections::dtos::ConditionOp,
+            crate::models::collection::CollectionConfig,
+            crate::models::collection::DenseVectorOptions,
+            crate::models::collection::SparseVectorOptions,
+            crate::models::collection::TFIDFOptions,
+            CollectionIndexingStatusResponse
+        )
+    ),
+    tags(
+        (name = "auth", description = "Authentication endpoints"),
+        (name = "collections", description = "Collection management endpoints")
+    ),
+    info(
+        title = "Cosdata API",
+        version = env!("CARGO_PKG_VERSION"),
+        description = "Cosdata Vector Database API",
+        license(
+            name = "Apache 2.0",
+            url = "https://www.apache.org/licenses/LICENSE-2.0"
+        )
+    )
+)]
+pub struct CombinedApiDoc;
+
+/// Simplified schema for collection indexing status to avoid complex type issues
+#[derive(utoipa::ToSchema, serde::Serialize)]
+pub struct CollectionIndexingStatusResponse {
+    pub collection_name: String,
+    pub total_transactions: u32,
+    pub completed_transactions: u32,
+    pub in_progress_transactions: u32,
+    pub not_started_transactions: u32,
+    pub total_records_indexed_completed: u64,
+    pub average_rate_per_second_completed: f32,
+    pub last_synced: String,
+}

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -145,6 +145,27 @@ pub struct IndexesApiDoc;
 )]
 pub struct SearchApiDoc;
 
+/// API documentation for version management endpoints
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        crate::api::vectordb::versions::controller::list_versions,
+        crate::api::vectordb::versions::controller::get_current_version,
+        crate::api::vectordb::versions::controller::set_current_version
+    ),
+    components(
+        schemas(
+            crate::api::vectordb::versions::dtos::VersionMetadata,
+            crate::api::vectordb::versions::dtos::VersionListResponse,
+            crate::api::vectordb::versions::dtos::CurrentVersionResponse
+        )
+    ),
+    tags(
+        (name = "versions", description = "Version management endpoints")
+    )
+)]
+pub struct VersionsApiDoc;
+
 /// API documentation for vector management endpoints
 #[derive(OpenApi)]
 #[openapi(
@@ -196,7 +217,10 @@ pub struct VectorsApiDoc;
         crate::api::vectordb::vectors::controller::query_vectors,
         crate::api::vectordb::vectors::controller::get_vector_by_id,
         crate::api::vectordb::vectors::controller::check_vector_existence,
-        crate::api::vectordb::vectors::controller::fetch_vector_neighbors
+        crate::api::vectordb::vectors::controller::fetch_vector_neighbors,
+        crate::api::vectordb::versions::controller::list_versions,
+        crate::api::vectordb::versions::controller::get_current_version,
+        crate::api::vectordb::versions::controller::set_current_version,
     ),
     components(
         schemas(
@@ -252,7 +276,10 @@ pub struct VectorsApiDoc;
             crate::api::vectordb::search::dtos::BatchSearchResponseDto,
             crate::api::vectordb::vectors::dtos::VectorsQueryDto,
             crate::api::vectordb::vectors::dtos::CreateVectorDto,
-            crate::api::vectordb::vectors::dtos::SimilarVector
+            crate::api::vectordb::vectors::dtos::SimilarVector,
+            crate::api::vectordb::versions::dtos::VersionMetadata,
+            crate::api::vectordb::versions::dtos::VersionListResponse,
+            crate::api::vectordb::versions::dtos::CurrentVersionResponse,
         )
     ),
     tags(
@@ -260,7 +287,8 @@ pub struct VectorsApiDoc;
         (name = "collections", description = "Collection management endpoints"),
         (name = "indexes", description = "Index management endpoints"),
         (name = "search", description = "Vector search endpoints"),
-        (name = "vectors", description = "Vector management endpoints")
+        (name = "vectors", description = "Vector management endpoints"),
+        (name = "versions", description = "Version management endpoints"),
     )
 )]
 pub struct CombinedApiDoc;
@@ -290,6 +318,12 @@ impl utoipa::Modify for SearchApiDoc {
 }
 
 impl utoipa::Modify for VectorsApiDoc {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        openapi.info = api_info().build();
+    }
+}
+
+impl utoipa::Modify for VersionsApiDoc {
     fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
         openapi.info = api_info().build();
     }

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -1,4 +1,17 @@
-use utoipa::OpenApi;
+use utoipa::{OpenApi, openapi};
+
+fn api_info() -> openapi::InfoBuilder {
+    openapi::InfoBuilder::new()
+        .title("Cosdata API")
+        .version(env!("CARGO_PKG_VERSION"))
+        .description(Some("Cosdata Vector Database API"))
+        .license(Some(
+            openapi::LicenseBuilder::new()
+                .name("Apache 2.0")
+                .url(Some("https://www.apache.org/licenses/LICENSE-2.0"))
+                .build()
+        ))
+}
 
 /// API documentation for authentication endpoints
 #[derive(OpenApi)]
@@ -15,15 +28,6 @@ use utoipa::OpenApi;
     ),
     tags(
         (name = "auth", description = "Authentication endpoints")
-    ),
-    info(
-        title = "Cosdata API",
-        version = env!("CARGO_PKG_VERSION"),
-        description = "Cosdata Vector Database API - Authentication",
-        license(
-            name = "Apache 2.0",
-            url = "https://www.apache.org/licenses/LICENSE-2.0"
-        )
     )
 )]
 pub struct AuthApiDoc;
@@ -63,18 +67,49 @@ pub struct AuthApiDoc;
     ),
     tags(
         (name = "collections", description = "Collection management endpoints")
-    ),
-    info(
-        title = "Cosdata API",
-        version = env!("CARGO_PKG_VERSION"),
-        description = "Cosdata Vector Database API - Collection Management",
-        license(
-            name = "Apache 2.0",
-            url = "https://www.apache.org/licenses/LICENSE-2.0"
-        )
     )
 )]
 pub struct CollectionsApiDoc;
+
+/// API documentation for index management endpoints
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        crate::api::vectordb::indexes::controller::create_dense_index,
+        crate::api::vectordb::indexes::controller::create_sparse_index,
+        crate::api::vectordb::indexes::controller::create_tf_idf_index,
+        crate::api::vectordb::indexes::controller::get_index,
+        crate::api::vectordb::indexes::controller::delete_index
+    ),
+    components(
+        schemas(
+            crate::api::vectordb::indexes::dtos::CreateDenseIndexDto,
+            crate::api::vectordb::indexes::dtos::CreateSparseIndexDto,
+            crate::api::vectordb::indexes::dtos::CreateTFIDFIndexDto,
+            crate::api::vectordb::indexes::dtos::IndexType,
+            crate::api::vectordb::indexes::dtos::SparseIndexQuantization,
+            crate::api::vectordb::indexes::dtos::DataType,
+            crate::api::vectordb::indexes::dtos::ValuesRange,
+            crate::api::vectordb::indexes::dtos::DenseIndexQuantizationDto,
+            crate::api::vectordb::indexes::dtos::HNSWHyperParamsDto,
+            crate::api::vectordb::indexes::dtos::DenseIndexParamsDto,
+            crate::models::schema_traits::DistanceMetricSchema,
+            crate::api::vectordb::indexes::dtos::IndexResponseDto,
+            crate::api::vectordb::indexes::dtos::IndexDetailsDto,
+            crate::api::vectordb::indexes::dtos::IndexInfo,
+            crate::api::vectordb::indexes::dtos::DenseIndexInfo,
+            crate::api::vectordb::indexes::dtos::SparseIndexInfo,
+            crate::api::vectordb::indexes::dtos::TfIdfIndexInfo,
+            crate::api::vectordb::indexes::dtos::QuantizationInfo,
+            crate::api::vectordb::indexes::dtos::RangeInfo,
+            crate::api::vectordb::indexes::dtos::HnswParamsInfo
+        )
+    ),
+    tags(
+        (name = "indexes", description = "Index management endpoints")
+    )
+)]
+pub struct IndexesApiDoc;
 
 /// Combined API documentation
 #[derive(OpenApi)]
@@ -89,7 +124,12 @@ pub struct CollectionsApiDoc;
         crate::api::vectordb::collections::controller::load_collection,
         crate::api::vectordb::collections::controller::unload_collection,
         crate::api::vectordb::collections::controller::get_loaded_collections,
-        crate::api::vectordb::collections::controller::list_collections
+        crate::api::vectordb::collections::controller::list_collections,
+        crate::api::vectordb::indexes::controller::create_dense_index,
+        crate::api::vectordb::indexes::controller::create_sparse_index,
+        crate::api::vectordb::indexes::controller::create_tf_idf_index,
+        crate::api::vectordb::indexes::controller::get_index,
+        crate::api::vectordb::indexes::controller::delete_index
     ),
     components(
         schemas(
@@ -110,26 +150,55 @@ pub struct CollectionsApiDoc;
             crate::models::collection::DenseVectorOptions,
             crate::models::collection::SparseVectorOptions,
             crate::models::collection::TFIDFOptions,
-            CollectionIndexingStatusResponse
+            CollectionIndexingStatusResponse,
+            crate::api::vectordb::indexes::dtos::CreateDenseIndexDto,
+            crate::api::vectordb::indexes::dtos::CreateSparseIndexDto,
+            crate::api::vectordb::indexes::dtos::CreateTFIDFIndexDto,
+            crate::api::vectordb::indexes::dtos::IndexType,
+            crate::api::vectordb::indexes::dtos::SparseIndexQuantization,
+            crate::api::vectordb::indexes::dtos::DataType,
+            crate::api::vectordb::indexes::dtos::ValuesRange,
+            crate::api::vectordb::indexes::dtos::DenseIndexQuantizationDto,
+            crate::api::vectordb::indexes::dtos::HNSWHyperParamsDto,
+            crate::api::vectordb::indexes::dtos::DenseIndexParamsDto,
+            crate::models::schema_traits::DistanceMetricSchema,
+            crate::api::vectordb::indexes::dtos::IndexResponseDto,
+            crate::api::vectordb::indexes::dtos::IndexDetailsDto,
+            crate::api::vectordb::indexes::dtos::IndexInfo,
+            crate::api::vectordb::indexes::dtos::DenseIndexInfo,
+            crate::api::vectordb::indexes::dtos::SparseIndexInfo,
+            crate::api::vectordb::indexes::dtos::TfIdfIndexInfo,
+            crate::api::vectordb::indexes::dtos::QuantizationInfo,
+            crate::api::vectordb::indexes::dtos::RangeInfo,
+            crate::api::vectordb::indexes::dtos::HnswParamsInfo
         )
     ),
     tags(
         (name = "auth", description = "Authentication endpoints"),
-        (name = "collections", description = "Collection management endpoints")
-    ),
-    info(
-        title = "Cosdata API",
-        version = env!("CARGO_PKG_VERSION"),
-        description = "Cosdata Vector Database API",
-        license(
-            name = "Apache 2.0",
-            url = "https://www.apache.org/licenses/LICENSE-2.0"
-        )
+        (name = "collections", description = "Collection management endpoints"),
+        (name = "indexes", description = "Index management endpoints")
     )
 )]
 pub struct CombinedApiDoc;
 
-/// Simplified schema for collection indexing status to avoid complex type issues
+impl utoipa::Modify for AuthApiDoc {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        openapi.info = api_info().build();
+    }
+}
+
+impl utoipa::Modify for CollectionsApiDoc {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        openapi.info = api_info().build();
+    }
+}
+
+impl utoipa::Modify for IndexesApiDoc {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        openapi.info = api_info().build();
+    }
+}
+
 #[derive(utoipa::ToSchema, serde::Serialize)]
 pub struct CollectionIndexingStatusResponse {
     pub collection_name: String,

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -166,6 +166,33 @@ pub struct SearchApiDoc;
 )]
 pub struct VersionsApiDoc;
 
+/// API documentation for transaction management endpoints
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        crate::api::vectordb::transactions::controller::create_transaction,
+        crate::api::vectordb::transactions::controller::commit_transaction,
+        crate::api::vectordb::transactions::controller::get_transaction_status,
+        crate::api::vectordb::transactions::controller::create_vector_in_transaction,
+        crate::api::vectordb::transactions::controller::delete_vector_by_id,
+        crate::api::vectordb::transactions::controller::abort_transaction,
+        crate::api::vectordb::transactions::controller::upsert
+    ),
+    components(
+        schemas(
+            crate::api::vectordb::transactions::dtos::CreateTransactionResponseDto,
+            crate::api::vectordb::transactions::dtos::UpsertDto,
+            crate::models::collection_transaction::TransactionStatus,
+            crate::models::collection_transaction::Progress,
+            crate::models::collection_transaction::Summary
+        )
+    ),
+    tags(
+        (name = "transactions", description = "Transaction management endpoints")
+    )
+)]
+pub struct TransactionsApiDoc;
+
 /// API documentation for vector management endpoints
 #[derive(OpenApi)]
 #[openapi(
@@ -221,6 +248,13 @@ pub struct VectorsApiDoc;
         crate::api::vectordb::versions::controller::list_versions,
         crate::api::vectordb::versions::controller::get_current_version,
         crate::api::vectordb::versions::controller::set_current_version,
+        crate::api::vectordb::transactions::controller::create_transaction,
+        crate::api::vectordb::transactions::controller::commit_transaction,
+        crate::api::vectordb::transactions::controller::get_transaction_status,
+        crate::api::vectordb::transactions::controller::create_vector_in_transaction,
+        crate::api::vectordb::transactions::controller::delete_vector_by_id,
+        crate::api::vectordb::transactions::controller::abort_transaction,
+        crate::api::vectordb::transactions::controller::upsert
     ),
     components(
         schemas(
@@ -280,6 +314,11 @@ pub struct VectorsApiDoc;
             crate::api::vectordb::versions::dtos::VersionMetadata,
             crate::api::vectordb::versions::dtos::VersionListResponse,
             crate::api::vectordb::versions::dtos::CurrentVersionResponse,
+            crate::api::vectordb::transactions::dtos::CreateTransactionResponseDto,
+            crate::api::vectordb::transactions::dtos::UpsertDto,
+            crate::models::collection_transaction::TransactionStatus,
+            crate::models::collection_transaction::Progress,
+            crate::models::collection_transaction::Summary
         )
     ),
     tags(
@@ -289,6 +328,7 @@ pub struct VectorsApiDoc;
         (name = "search", description = "Vector search endpoints"),
         (name = "vectors", description = "Vector management endpoints"),
         (name = "versions", description = "Version management endpoints"),
+        (name = "transactions", description = "Transaction management endpoints")
     )
 )]
 pub struct CombinedApiDoc;
@@ -318,6 +358,12 @@ impl utoipa::Modify for SearchApiDoc {
 }
 
 impl utoipa::Modify for VectorsApiDoc {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        openapi.info = api_info().build();
+    }
+}
+
+impl utoipa::Modify for TransactionsApiDoc {
     fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
         openapi.info = api_info().build();
     }

--- a/src/api/vectordb/collections/controller.rs
+++ b/src/api/vectordb/collections/controller.rs
@@ -3,11 +3,29 @@ use actix_web::{web, HttpResponse, Result};
 use crate::app_context::AppContext;
 
 use super::{
-    dtos::{CreateCollectionDto, GetCollectionsDto},
+    dtos::{
+        CreateCollectionDto, CreateCollectionDtoResponse, GetCollectionsDto, GetCollectionsResponseDto,
+        ListCollectionsResponseDto,
+    },
     service,
 };
 use crate::api::vectordb::collections::error::CollectionsError;
+use crate::api::openapi::CollectionIndexingStatusResponse;
 
+/// Create a new collection
+///
+/// Creates a new vector collection with the specified configuration.
+#[utoipa::path(
+    post,
+    path = "/vectordb/collections",
+    request_body = CreateCollectionDto,
+    responses(
+        (status = 201, description = "Collection created successfully", body = CreateCollectionDtoResponse),
+        (status = 400, description = "Invalid request"),
+        (status = 500, description = "Server error")
+    ),
+    tag = "collections"
+)]
 pub(crate) async fn create_collection(
     web::Json(create_collection_dto): web::Json<CreateCollectionDto>,
     ctx: web::Data<AppContext>,
@@ -18,6 +36,21 @@ pub(crate) async fn create_collection(
     Ok(HttpResponse::Created().json(create_collection_response_dto))
 }
 
+/// Get all collections
+///
+/// Returns a list of all collections.
+#[utoipa::path(
+    get,
+    path = "/vectordb/collections",
+    params(
+        GetCollectionsDto
+    ),
+    responses(
+        (status = 200, description = "List of collections", body = Vec<GetCollectionsResponseDto>),
+        (status = 500, description = "Server error")
+    ),
+    tag = "collections"
+)]
 pub(crate) async fn get_collections(
     web::Query(get_collections_dto): web::Query<GetCollectionsDto>,
     ctx: web::Data<AppContext>,
@@ -26,6 +59,22 @@ pub(crate) async fn get_collections(
     Ok(HttpResponse::Ok().json(collections))
 }
 
+/// Get collection by ID
+///
+/// Returns a specific collection by its ID.
+#[utoipa::path(
+    get,
+    path = "/vectordb/collections/{collection_id}",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier")
+    ),
+    responses(
+        (status = 200, description = "Collection information"),
+        (status = 400, description = "Collection not found"),
+        (status = 500, description = "Server error")
+    ),
+    tag = "collections"
+)]
 pub(crate) async fn get_collection_by_id(
     collection_id: web::Path<String>,
     ctx: web::Data<AppContext>,
@@ -34,14 +83,59 @@ pub(crate) async fn get_collection_by_id(
     Ok(HttpResponse::Ok().json(&collection.meta))
 }
 
+/// Get collection indexing status
+///
+/// Returns the indexing status of a collection.
+#[utoipa::path(
+    get,
+    path = "/vectordb/collections/{collection_id}/indexing_status",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier")
+    ),
+    responses(
+        (status = 200, description = "Collection indexing status", body = CollectionIndexingStatusResponse),
+        (status = 400, description = "Collection not found"),
+        (status = 500, description = "Server error")
+    ),
+    tag = "collections"
+)]
 pub(crate) async fn get_collection_indexing_status(
     collection_id: web::Path<String>,
     ctx: web::Data<AppContext>,
 ) -> Result<HttpResponse> {
     let status = service::get_collection_indexing_status(ctx.into_inner(), &collection_id).await?;
-    Ok(HttpResponse::Ok().json(status))
+    
+    // Convert to the simplified response format for the API docs
+    let response = CollectionIndexingStatusResponse {
+        collection_name: status.collection_name,
+        total_transactions: status.status_summary.total_transactions,
+        completed_transactions: status.status_summary.completed_transactions,
+        in_progress_transactions: status.status_summary.in_progress_transactions,
+        not_started_transactions: status.status_summary.not_started_transactions,
+        total_records_indexed_completed: status.status_summary.total_records_indexed_completed,
+        average_rate_per_second_completed: status.status_summary.average_rate_per_second_completed,
+        last_synced: status.last_synced.to_rfc3339(),
+    };
+    
+    Ok(HttpResponse::Ok().json(response))
 }
 
+/// Delete collection by ID
+///
+/// Deletes a collection by its ID.
+#[utoipa::path(
+    delete,
+    path = "/vectordb/collections/{collection_id}",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier")
+    ),
+    responses(
+        (status = 204, description = "Collection deleted successfully"),
+        (status = 400, description = "Collection not found"),
+        (status = 500, description = "Server error")
+    ),
+    tag = "collections"
+)]
 pub(crate) async fn delete_collection_by_id(
     collection_id: web::Path<String>,
     ctx: web::Data<AppContext>,
@@ -50,6 +144,22 @@ pub(crate) async fn delete_collection_by_id(
     Ok(HttpResponse::NoContent().finish())
 }
 
+/// Load collection into memory
+///
+/// Loads a collection into memory for faster access.
+#[utoipa::path(
+    post,
+    path = "/vectordb/collections/{collection_id}/load",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier")
+    ),
+    responses(
+        (status = 200, description = "Collection loaded successfully"),
+        (status = 400, description = "Collection not found"),
+        (status = 500, description = "Server error")
+    ),
+    tag = "collections"
+)]
 pub(crate) async fn load_collection(
     collection_id: web::Path<String>,
     ctx: web::Data<AppContext>,
@@ -58,6 +168,22 @@ pub(crate) async fn load_collection(
     Ok(HttpResponse::Ok().json(&collection.meta))
 }
 
+/// Unload collection from memory
+///
+/// Unloads a collection from memory.
+#[utoipa::path(
+    post,
+    path = "/vectordb/collections/{collection_id}/unload",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier")
+    ),
+    responses(
+        (status = 200, description = "Collection unloaded successfully"),
+        (status = 400, description = "Collection not found"),
+        (status = 500, description = "Server error")
+    ),
+    tag = "collections"
+)]
 pub(crate) async fn unload_collection(
     collection_id: web::Path<String>,
     ctx: web::Data<AppContext>,
@@ -69,11 +195,35 @@ pub(crate) async fn unload_collection(
     )))
 }
 
+/// Get loaded collections
+///
+/// Returns a list of all collections currently loaded in memory.
+#[utoipa::path(
+    get,
+    path = "/vectordb/collections/loaded",
+    responses(
+        (status = 200, description = "List of loaded collections", body = Vec<String>),
+        (status = 500, description = "Server error")
+    ),
+    tag = "collections"
+)]
 pub(crate) async fn get_loaded_collections(ctx: web::Data<AppContext>) -> Result<HttpResponse> {
     let collections = service::get_loaded_collections(ctx.into_inner()).await?;
     Ok(HttpResponse::Ok().json(collections))
 }
 
+/// List all collections
+///
+/// Returns a list of all collections with summary information.
+#[utoipa::path(
+    get,
+    path = "/vectordb/collections/list",
+    responses(
+        (status = 200, description = "List of collections", body = ListCollectionsResponseDto),
+        (status = 500, description = "Server error")
+    ),
+    tag = "collections"
+)]
 pub(crate) async fn list_collections(
     ctx: web::Data<AppContext>,
 ) -> Result<HttpResponse, CollectionsError> {

--- a/src/api/vectordb/collections/dtos.rs
+++ b/src/api/vectordb/collections/dtos.rs
@@ -3,10 +3,14 @@ use crate::models::collection::{
     CollectionConfig, DenseVectorOptions, SparseVectorOptions, TFIDFOptions,
 };
 use serde::{Deserialize, Serialize};
+use utoipa::{ToSchema, IntoParams};
 
-#[derive(Deserialize)]
+// Instead of implementing ToSchema for FieldValue, we'll use value_type in the schema attribute
+
+#[derive(Deserialize, ToSchema)]
 pub(crate) struct MetadataField {
     pub name: String,
+    #[schema(value_type = Vec<String>, example = "[\"value1\", \"value2\", 123]")]
     pub values: Vec<metadata::FieldValue>,
 }
 
@@ -20,14 +24,14 @@ impl TryFrom<MetadataField> for metadata::schema::MetadataField {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum ConditionOp {
     And,
     Or,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, ToSchema)]
 pub(crate) struct SupportedCondition {
     pub op: ConditionOp,
     pub field_names: Vec<String>,
@@ -45,7 +49,7 @@ impl TryFrom<SupportedCondition> for metadata::schema::SupportedCondition {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, ToSchema)]
 pub(crate) struct MetadataSchemaParam {
     pub fields: Vec<MetadataField>,
     pub supported_conditions: Vec<SupportedCondition>,
@@ -69,7 +73,7 @@ impl TryFrom<MetadataSchemaParam> for metadata::schema::MetadataSchema {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, ToSchema)]
 pub(crate) struct CreateCollectionDto {
     pub name: String,
     pub description: Option<String>,
@@ -82,17 +86,18 @@ pub(crate) struct CreateCollectionDto {
     pub store_raw_text: bool,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 pub(crate) struct CreateCollectionDtoResponse {
     pub id: String,
     pub name: String,
     pub description: Option<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, ToSchema)]
+#[derive(IntoParams)]
 pub(crate) struct GetCollectionsDto {}
 
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 pub(crate) struct GetCollectionsResponseDto {
     pub name: String,
     pub description: Option<String>,
@@ -141,13 +146,13 @@ mod tests {
     }
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, ToSchema)]
 pub(crate) struct CollectionSummaryDto {
     pub name: String,
     pub description: Option<String>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, ToSchema)]
 pub(crate) struct ListCollectionsResponseDto {
     pub collections: Vec<CollectionSummaryDto>,
 }

--- a/src/api/vectordb/collections/mod.rs
+++ b/src/api/vectordb/collections/mod.rs
@@ -1,6 +1,6 @@
 use actix_web::{web, Scope};
-mod controller;
-mod dtos;
+pub(crate) mod controller;
+pub(crate) mod dtos;
 mod error;
 mod repo;
 pub(crate) mod service;
@@ -8,7 +8,7 @@ pub(crate) mod service;
 pub(crate) fn collections_module() -> Scope {
     web::scope("/collections")
         .route("", web::post().to(controller::create_collection))
-        .route("", web::get().to(controller::list_collections))
+        .route("/list", web::get().to(controller::list_collections))
         .route("", web::get().to(controller::get_collections))
         .route("/loaded", web::get().to(controller::get_loaded_collections))
         .route(

--- a/src/api/vectordb/indexes/controller.rs
+++ b/src/api/vectordb/indexes/controller.rs
@@ -2,13 +2,32 @@ use actix_web::{web, HttpResponse, Result};
 
 use crate::app_context::AppContext;
 
-use super::dtos::{CreateTFIDFIndexDto, IndexType};
+use super::dtos::{CreateTFIDFIndexDto, IndexType, IndexResponseDto, IndexDetailsDto};
 use super::error::IndexesError;
 use super::{
     dtos::{CreateDenseIndexDto, CreateSparseIndexDto},
     service,
 };
 
+/// Create a dense vector index for a collection
+///
+/// Creates a new dense vector index for the specified collection
+#[utoipa::path(
+    post,
+    path = "/vectordb/collections/{collection_id}/indexes/dense",
+    request_body = CreateDenseIndexDto,
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier")
+    ),
+    responses(
+        (status = 201, description = "Dense index created successfully", body = IndexResponseDto),
+        (status = 400, description = "Bad request", body = serde_json::Value),
+        (status = 404, description = "Collection not found", body = serde_json::Value),
+        (status = 409, description = "Index already exists", body = serde_json::Value),
+        (status = 500, description = "Internal server error", body = serde_json::Value)
+    ),
+    tag = "indexes"
+)]
 pub(crate) async fn create_dense_index(
     web::Json(create_index_dto): web::Json<CreateDenseIndexDto>,
     ctx: web::Data<AppContext>,
@@ -20,9 +39,30 @@ pub(crate) async fn create_dense_index(
         ctx.into_inner(),
     )
     .await?;
-    Ok(HttpResponse::Created().json(serde_json::json!({})))
+    Ok(HttpResponse::Created().json(IndexResponseDto {
+        message: "Dense index created successfully".to_string(),
+    }))
 }
 
+/// Create a sparse vector index for a collection
+///
+/// Creates a new sparse vector index for the specified collection
+#[utoipa::path(
+    post,
+    path = "/vectordb/collections/{collection_id}/indexes/sparse",
+    request_body = CreateSparseIndexDto,
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier")
+    ),
+    responses(
+        (status = 201, description = "Sparse index created successfully", body = IndexResponseDto),
+        (status = 400, description = "Bad request", body = serde_json::Value),
+        (status = 404, description = "Collection not found", body = serde_json::Value),
+        (status = 409, description = "Index already exists", body = serde_json::Value),
+        (status = 500, description = "Internal server error", body = serde_json::Value)
+    ),
+    tag = "indexes"
+)]
 pub(crate) async fn create_sparse_index(
     web::Json(create_index_dto): web::Json<CreateSparseIndexDto>,
     ctx: web::Data<AppContext>,
@@ -34,9 +74,30 @@ pub(crate) async fn create_sparse_index(
         ctx.into_inner(),
     )
     .await?;
-    Ok(HttpResponse::Created().json(serde_json::json!({})))
+    Ok(HttpResponse::Created().json(IndexResponseDto {
+        message: "Sparse index created successfully".to_string(),
+    }))
 }
 
+/// Create a TF-IDF index for a collection
+///
+/// Creates a new TF-IDF index for the specified collection
+#[utoipa::path(
+    post,
+    path = "/vectordb/collections/{collection_id}/indexes/tf-idf",
+    request_body = CreateTFIDFIndexDto,
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier")
+    ),
+    responses(
+        (status = 201, description = "TF-IDF index created successfully", body = IndexResponseDto),
+        (status = 400, description = "Bad request", body = serde_json::Value),
+        (status = 404, description = "Collection not found", body = serde_json::Value),
+        (status = 409, description = "Index already exists", body = serde_json::Value),
+        (status = 500, description = "Internal server error", body = serde_json::Value)
+    ),
+    tag = "indexes"
+)]
 pub(crate) async fn create_tf_idf_index(
     web::Json(create_index_dto): web::Json<CreateTFIDFIndexDto>,
     ctx: web::Data<AppContext>,
@@ -48,9 +109,27 @@ pub(crate) async fn create_tf_idf_index(
         ctx.into_inner(),
     )
     .await?;
-    Ok(HttpResponse::Created().json(serde_json::json!({})))
+    Ok(HttpResponse::Created().json(IndexResponseDto {
+        message: "TF-IDF index created successfully".to_string(),
+    }))
 }
 
+/// Get indexes for a collection
+///
+/// Retrieves all indexes associated with the specified collection
+#[utoipa::path(
+    get,
+    path = "/vectordb/collections/{collection_id}/indexes",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier")
+    ),
+    responses(
+        (status = 200, description = "Indexes retrieved successfully", body = IndexDetailsDto),
+        (status = 404, description = "Collection not found", body = serde_json::Value),
+        (status = 500, description = "Internal server error", body = serde_json::Value)
+    ),
+    tag = "indexes"
+)]
 pub(crate) async fn get_index(
     collection_id: web::Path<String>,
     ctx: web::Data<AppContext>,
@@ -59,6 +138,23 @@ pub(crate) async fn get_index(
     Ok(HttpResponse::Ok().json(index_details))
 }
 
+/// Delete an index from a collection
+///
+/// Deletes the specified index from a collection
+#[utoipa::path(
+    delete,
+    path = "/vectordb/collections/{collection_id}/indexes/{index_type}",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier"),
+        ("index_type" = IndexType, Path, description = "Type of index to delete (dense, sparse or tf_idf)")
+    ),
+    responses(
+        (status = 204, description = "Index successfully deleted"),
+        (status = 404, description = "Collection or index not found", body = serde_json::Value),
+        (status = 500, description = "Internal server error", body = serde_json::Value)
+    ),
+    tag = "indexes"
+)]
 pub(crate) async fn delete_index(
     path: web::Path<(String, IndexType)>,
     ctx: web::Data<AppContext>,

--- a/src/api/vectordb/indexes/service.rs
+++ b/src/api/vectordb/indexes/service.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::app_context::AppContext;
 
 use super::{
-    dtos::{CreateDenseIndexDto, CreateSparseIndexDto, CreateTFIDFIndexDto, IndexType},
+    dtos::{CreateDenseIndexDto, CreateSparseIndexDto, CreateTFIDFIndexDto, IndexDetailsDto, IndexType},
     error::IndexesError,
     repo,
 };
@@ -17,7 +17,7 @@ pub(crate) async fn create_dense_index(
         ctx,
         collection_id,
         create_index_dto.name,
-        create_index_dto.distance_metric_type,
+        create_index_dto.distance_metric_type.into(),
         create_index_dto.quantization,
         create_index_dto.index,
     )
@@ -58,8 +58,12 @@ pub(crate) async fn create_tf_idf_index(
 pub(crate) async fn get_index(
     collection_id: String,
     ctx: Arc<AppContext>,
-) -> Result<serde_json::Value, IndexesError> {
-    repo::get_index(ctx, collection_id).await
+) -> Result<IndexDetailsDto, IndexesError> {
+    let index_json = repo::get_index(ctx, collection_id).await?;
+    
+    // Convert the JSON value to our IndexDetailsDto format
+    serde_json::from_value::<IndexDetailsDto>(index_json)
+        .map_err(|_e| IndexesError::FailedToGetAppEnv)
 }
 
 pub(crate) async fn delete_index(

--- a/src/api/vectordb/search/controller.rs
+++ b/src/api/vectordb/search/controller.rs
@@ -4,14 +4,32 @@ use crate::app_context::AppContext;
 use crate::models::collection_cache::CollectionCacheExt;
 
 use super::dtos::{
-    BatchDenseSearchRequestDto, BatchSearchTFIDFDocumentsDto, BatchSparseSearchRequestDto,
+    BatchDenseSearchRequestDto, BatchSearchResponseDto, BatchSearchTFIDFDocumentsDto, BatchSparseSearchRequestDto,
     DenseSearchRequestDto, FindSimilarTFIDFDocumentDto, HybridSearchRequestDto,
-    SparseSearchRequestDto,
+    SearchResponseDto, SparseSearchRequestDto
 };
 use super::error::SearchError;
 
 use super::service;
 
+/// Search using a dense vector embedding
+///
+/// Performs a similarity search using dense vector embeddings with optional filtering.
+#[utoipa::path(
+    post,
+    path = "/vectordb/collections/{collection_id}/search/dense",
+    tag = "search",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier")
+    ),
+    request_body = DenseSearchRequestDto,
+    responses(
+        (status = 200, description = "Search successfully completed", body = SearchResponseDto),
+        (status = 404, description = "Collection not found", body = String),
+        (status = 400, description = "Invalid filter or other request error", body = String),
+        (status = 500, description = "Internal server error", body = String)
+    )
+)]
 pub(crate) async fn dense_search(
     path: web::Path<String>,
     web::Json(body): web::Json<DenseSearchRequestDto>,
@@ -27,7 +45,24 @@ pub(crate) async fn dense_search(
     Ok(HttpResponse::Ok().json(results))
 }
 
-// Route: `POST /collections/{collection_id}/vectors/search/batch-dense`
+/// Batch search using dense vector embeddings
+///
+/// Performs multiple similarity searches using dense vector embeddings in a single request.
+#[utoipa::path(
+    post,
+    path = "/vectordb/collections/{collection_id}/search/batch-dense",
+    tag = "search",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier")
+    ),
+    request_body = BatchDenseSearchRequestDto,
+    responses(
+        (status = 200, description = "Batch search successfully completed", body = BatchSearchResponseDto),
+        (status = 404, description = "Collection not found", body = String),
+        (status = 400, description = "Invalid filter or other request error", body = String),
+        (status = 500, description = "Internal server error", body = String)
+    )
+)]
 pub(crate) async fn batch_dense_search(
     path: web::Path<String>,
     web::Json(body): web::Json<BatchDenseSearchRequestDto>,
@@ -44,6 +79,24 @@ pub(crate) async fn batch_dense_search(
     Ok(HttpResponse::Ok().json(results))
 }
 
+/// Search using sparse vector embeddings
+///
+/// Performs a similarity search using sparse vector embeddings.
+#[utoipa::path(
+    post,
+    path = "/vectordb/collections/{collection_id}/search/sparse",
+    tag = "search",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier")
+    ),
+    request_body = SparseSearchRequestDto,
+    responses(
+        (status = 200, description = "Search successfully completed", body = SearchResponseDto),
+        (status = 404, description = "Collection not found", body = String),
+        (status = 400, description = "Invalid request error", body = String),
+        (status = 500, description = "Internal server error", body = String)
+    )
+)]
 pub(crate) async fn sparse_search(
     path: web::Path<String>,
     web::Json(body): web::Json<SparseSearchRequestDto>,
@@ -57,6 +110,24 @@ pub(crate) async fn sparse_search(
     Ok(HttpResponse::Ok().json(results))
 }
 
+/// Batch search using sparse vector embeddings
+///
+/// Performs multiple similarity searches using sparse vector embeddings in a single request.
+#[utoipa::path(
+    post,
+    path = "/vectordb/collections/{collection_id}/search/batch-sparse",
+    tag = "search",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier")
+    ),
+    request_body = BatchSparseSearchRequestDto,
+    responses(
+        (status = 200, description = "Batch search successfully completed", body = BatchSearchResponseDto),
+        (status = 404, description = "Collection not found", body = String),
+        (status = 400, description = "Invalid request error", body = String),
+        (status = 500, description = "Internal server error", body = String)
+    )
+)]
 pub(crate) async fn batch_sparse_search(
     path: web::Path<String>,
     web::Json(body): web::Json<BatchSparseSearchRequestDto>,
@@ -70,6 +141,24 @@ pub(crate) async fn batch_sparse_search(
     Ok(HttpResponse::Ok().json(results))
 }
 
+/// Hybrid search combining different search approaches
+///
+/// Performs a hybrid search combining multiple search strategies (dense/sparse/TFIDF).
+#[utoipa::path(
+    post,
+    path = "/vectordb/collections/{collection_id}/search/hybrid",
+    tag = "search",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier")
+    ),
+    request_body = HybridSearchRequestDto,
+    responses(
+        (status = 200, description = "Hybrid search successfully completed", body = SearchResponseDto),
+        (status = 404, description = "Collection not found", body = String),
+        (status = 400, description = "Invalid request error", body = String),
+        (status = 500, description = "Internal server error", body = String)
+    )
+)]
 pub(crate) async fn hybrid_search(
     path: web::Path<String>,
     web::Json(body): web::Json<HybridSearchRequestDto>,
@@ -83,6 +172,24 @@ pub(crate) async fn hybrid_search(
     Ok(HttpResponse::Ok().json(results))
 }
 
+/// Search for similar documents using TF-IDF
+///
+/// Performs a search for similar documents using TF-IDF scoring.
+#[utoipa::path(
+    post,
+    path = "/vectordb/collections/{collection_id}/search/tf-idf",
+    tag = "search",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier")
+    ),
+    request_body = FindSimilarTFIDFDocumentDto,
+    responses(
+        (status = 200, description = "TF-IDF search successfully completed", body = SearchResponseDto),
+        (status = 404, description = "Collection not found", body = String),
+        (status = 400, description = "Invalid request error", body = String),
+        (status = 500, description = "Internal server error", body = String)
+    )
+)]
 pub(crate) async fn tf_idf_search(
     path: web::Path<String>,
     web::Json(body): web::Json<FindSimilarTFIDFDocumentDto>,
@@ -96,6 +203,24 @@ pub(crate) async fn tf_idf_search(
     Ok(HttpResponse::Ok().json(results))
 }
 
+/// Batch search for similar documents using TF-IDF
+///
+/// Performs multiple searches for similar documents using TF-IDF scoring in a single request.
+#[utoipa::path(
+    post,
+    path = "/vectordb/collections/{collection_id}/search/batch-tf-idf",
+    tag = "search",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier")
+    ),
+    request_body = BatchSearchTFIDFDocumentsDto,
+    responses(
+        (status = 200, description = "Batch TF-IDF search successfully completed", body = BatchSearchResponseDto),
+        (status = 404, description = "Collection not found", body = String),
+        (status = 400, description = "Invalid request error", body = String),
+        (status = 500, description = "Internal server error", body = String)
+    )
+)]
 pub(crate) async fn batch_tf_idf_search(
     path: web::Path<String>,
     web::Json(body): web::Json<BatchSearchTFIDFDocumentsDto>,

--- a/src/api/vectordb/search/dtos.rs
+++ b/src/api/vectordb/search/dtos.rs
@@ -11,22 +11,24 @@ fn default_fusion_constant_k() -> f32 {
     60.0
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, utoipa::ToSchema)]
 pub(crate) struct DenseSearchRequestDto {
     pub query_vector: Vec<f32>,
     pub top_k: Option<usize>,
+    #[schema(value_type = Option<String>)]
     pub filter: Option<Filter>,
     #[serde(default)]
     pub return_raw_text: bool,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, utoipa::ToSchema)]
 pub(crate) struct BatchDenseSearchRequestQueryDto {
     pub vector: Vec<f32>,
+    #[schema(value_type = Option<String>)]
     pub filter: Option<Filter>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, utoipa::ToSchema)]
 pub(crate) struct BatchDenseSearchRequestDto {
     pub queries: Vec<BatchDenseSearchRequestQueryDto>,
     pub top_k: Option<usize>,
@@ -34,8 +36,9 @@ pub(crate) struct BatchDenseSearchRequestDto {
     pub return_raw_text: bool,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, utoipa::ToSchema)]
 pub(crate) struct SparseSearchRequestDto {
+    #[schema(value_type = Vec<String>)]
     pub query_terms: Vec<SparsePair>,
     pub top_k: Option<usize>,
     pub early_terminate_threshold: Option<f32>,
@@ -43,8 +46,9 @@ pub(crate) struct SparseSearchRequestDto {
     pub return_raw_text: bool,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, utoipa::ToSchema)]
 pub(crate) struct BatchSparseSearchRequestDto {
+    #[schema(value_type = Vec<Vec<String>>)]
     pub query_terms_list: Vec<Vec<SparsePair>>,
     pub top_k: Option<usize>,
     pub early_terminate_threshold: Option<f32>,
@@ -52,7 +56,7 @@ pub(crate) struct BatchSparseSearchRequestDto {
     pub return_raw_text: bool,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, utoipa::ToSchema)]
 pub(crate) struct HybridSearchRequestDto {
     #[serde(flatten)]
     pub query: HybridSearchQuery,
@@ -64,11 +68,12 @@ pub(crate) struct HybridSearchRequestDto {
     pub return_raw_text: bool,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, utoipa::ToSchema)]
 #[serde(untagged)]
 pub(crate) enum HybridSearchQuery {
     DenseAndSparse {
         query_vector: Vec<f32>,
+        #[schema(value_type = Vec<String>)]
         query_terms: Vec<SparsePair>,
         sparse_early_terminate_threshold: Option<f32>,
     },
@@ -77,35 +82,38 @@ pub(crate) enum HybridSearchQuery {
         query_text: String,
     },
     SparseAndTFIDF {
+        #[schema(value_type = Vec<String>)]
         query_terms: Vec<SparsePair>,
         query_text: String,
         sparse_early_terminate_threshold: Option<f32>,
     },
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, utoipa::ToSchema)]
 pub(crate) struct SearchResultItemDto {
+    #[schema(value_type = String)]
     pub id: VectorId,
+    #[schema(value_type = Option<String>)]
     pub document_id: Option<DocumentId>,
     pub score: f32,
     pub text: Option<String>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, utoipa::ToSchema)]
 pub(crate) struct SearchResponseDto {
     pub results: Vec<SearchResultItemDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warning: Option<String>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, utoipa::ToSchema)]
 pub(crate) struct BatchSearchResponseDto {
     pub responses: Vec<SearchResponseDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warning: Option<String>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, utoipa::ToSchema)]
 pub(crate) struct FindSimilarTFIDFDocumentDto {
     pub query: String,
     pub top_k: Option<usize>,
@@ -113,7 +121,7 @@ pub(crate) struct FindSimilarTFIDFDocumentDto {
     pub return_raw_text: bool,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, utoipa::ToSchema)]
 pub(crate) struct BatchSearchTFIDFDocumentsDto {
     pub queries: Vec<String>,
     pub top_k: Option<usize>,

--- a/src/api/vectordb/search/mod.rs
+++ b/src/api/vectordb/search/mod.rs
@@ -4,7 +4,7 @@ use controller::{
     sparse_search, tf_idf_search,
 };
 
-mod controller;
+pub mod controller;
 pub(crate) mod dtos;
 pub(crate) mod error;
 pub(crate) mod repo;

--- a/src/api/vectordb/sync_transaction/controller.rs
+++ b/src/api/vectordb/sync_transaction/controller.rs
@@ -7,6 +7,24 @@ use crate::{
     models::collection_cache::CollectionCacheExt,
 };
 
+/// Upsert vectors into a collection with a synchronous transaction
+///
+/// This API provides a simplified way to upsert vectors without managing transaction lifecycle.
+/// A transaction is created, vectors are upserted, and the transaction is committed in a single request.
+#[utoipa::path(
+    post,
+    path = "/vectordb/collections/{collection_id}/sync_transaction/upsert",
+    tag = "sync_transactions",
+    params(
+        ("collection_id" = String, Path, description = "Collection ID")
+    ),
+    request_body = UpsertDto,
+    responses(
+        (status = 200, description = "Vectors upserted successfully"),
+        (status = 404, description = "Collection not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 pub(crate) async fn upsert(
     collection_id: web::Path<String>,
     ctx: web::Data<AppContext>,
@@ -22,6 +40,24 @@ pub(crate) async fn upsert(
     Ok(HttpResponse::Ok().finish())
 }
 
+/// Delete a vector by ID using a synchronous transaction
+///
+/// This API provides a simplified way to delete a vector without managing transaction lifecycle.
+/// A transaction is created, vector is deleted, and the transaction is committed in a single request.
+#[utoipa::path(
+    delete,
+    path = "/vectordb/collections/{collection_id}/sync_transaction/vectors/{vector_id}",
+    tag = "sync_transactions",
+    params(
+        ("collection_id" = String, Path, description = "Collection ID"),
+        ("vector_id" = String, Path, description = "Vector ID to delete")
+    ),
+    responses(
+        (status = 204, description = "Vector deleted successfully"),
+        (status = 404, description = "Collection or vector not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 pub(crate) async fn delete_vector_by_id(
     path: web::Path<(String, String)>,
     ctx: web::Data<AppContext>,

--- a/src/api/vectordb/sync_transaction/mod.rs
+++ b/src/api/vectordb/sync_transaction/mod.rs
@@ -1,4 +1,4 @@
-mod controller;
+pub mod controller;
 mod repo;
 mod service;
 

--- a/src/api/vectordb/transactions/controller.rs
+++ b/src/api/vectordb/transactions/controller.rs
@@ -3,9 +3,26 @@ use actix_web::{web, HttpResponse};
 use crate::api::vectordb::vectors::dtos::CreateVectorDto;
 use crate::app_context::AppContext;
 use crate::models::collection_cache::CollectionCacheExt;
+use crate::models::collection_transaction::TransactionStatus;
 
-use super::{dtos::UpsertDto, error::TransactionError, service};
+use super::{dtos::{CreateTransactionResponseDto, UpsertDto}, error::TransactionError, service};
 
+/// Create a new transaction for a collection
+///
+/// Creates a new transaction for modifying vectors in a collection.
+#[utoipa::path(
+    post,
+    path = "/vectordb/collections/{collection_id}/transactions",
+    tag = "transactions",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier")
+    ),
+    responses(
+        (status = 200, description = "Transaction created successfully", body = CreateTransactionResponseDto),
+        (status = 400, description = "Failed to create transaction"),
+        (status = 409, description = "There is an ongoing transaction")
+    )
+)]
 pub(crate) async fn create_transaction(
     collection_id: web::Path<String>,
     ctx: web::Data<AppContext>,
@@ -20,6 +37,22 @@ pub(crate) async fn create_transaction(
     Ok(HttpResponse::Ok().json(transaction))
 }
 
+/// Commit a transaction
+///
+/// Commits all changes in the transaction to the collection.
+#[utoipa::path(
+    post,
+    path = "/vectordb/collections/{collection_id}/transactions/{transaction_id}/commit",
+    tag = "transactions",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier"),
+        ("transaction_id" = u64, Path, description = "Transaction identifier")
+    ),
+    responses(
+        (status = 204, description = "Transaction committed successfully"),
+        (status = 400, description = "Failed to commit transaction")
+    )
+)]
 pub(crate) async fn commit_transaction(
     params: web::Path<(String, u64)>,
     ctx: web::Data<AppContext>,
@@ -33,6 +66,23 @@ pub(crate) async fn commit_transaction(
     Ok(HttpResponse::NoContent().finish())
 }
 
+/// Get transaction status
+///
+/// Gets the current status of a transaction.
+#[utoipa::path(
+    get,
+    path = "/vectordb/collections/{collection_id}/transactions/{transaction_id}/status",
+    tag = "transactions",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier"),
+        ("transaction_id" = u64, Path, description = "Transaction identifier")
+    ),
+    responses(
+        (status = 200, description = "Transaction status retrieved successfully", body = TransactionStatus),
+        (status = 400, description = "Failed to get transaction status"),
+        (status = 404, description = "Transaction not found")
+    )
+)]
 pub(crate) async fn get_transaction_status(
     params: web::Path<(String, u64)>,
     ctx: web::Data<AppContext>,
@@ -51,6 +101,24 @@ pub(crate) async fn get_transaction_status(
     Ok(HttpResponse::Ok().json(status))
 }
 
+/// Create a vector in a transaction
+///
+/// Creates a new vector as part of an ongoing transaction.
+#[utoipa::path(
+    post,
+    path = "/vectordb/collections/{collection_id}/transactions/{transaction_id}/vectors",
+    tag = "transactions",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier"),
+        ("transaction_id" = u64, Path, description = "Transaction identifier")
+    ),
+    request_body = CreateVectorDto,
+    responses(
+        (status = 200, description = "Vector created successfully"),
+        (status = 400, description = "Failed to create vector"),
+        (status = 404, description = "Transaction not found")
+    )
+)]
 pub(crate) async fn create_vector_in_transaction(
     params: web::Path<(String, u64)>,
     web::Json(create_vector_dto): web::Json<CreateVectorDto>,
@@ -70,6 +138,23 @@ pub(crate) async fn create_vector_in_transaction(
     Ok(HttpResponse::Ok().finish())
 }
 
+/// Abort a transaction
+///
+/// Aborts an ongoing transaction and discards all changes.
+#[utoipa::path(
+    post,
+    path = "/vectordb/collections/{collection_id}/transactions/{transaction_id}/abort",
+    tag = "transactions",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier"),
+        ("transaction_id" = u64, Path, description = "Transaction identifier")
+    ),
+    responses(
+        (status = 204, description = "Transaction aborted successfully"),
+        (status = 400, description = "Failed to abort transaction"),
+        (status = 404, description = "Transaction not found")
+    )
+)]
 pub(crate) async fn abort_transaction(
     params: web::Path<(String, u64)>,
     ctx: web::Data<AppContext>,
@@ -82,6 +167,24 @@ pub(crate) async fn abort_transaction(
     Ok(HttpResponse::NoContent().finish())
 }
 
+/// Delete a vector in a transaction
+///
+/// Deletes a vector by its ID as part of an ongoing transaction.
+#[utoipa::path(
+    delete,
+    path = "/vectordb/collections/{collection_id}/transactions/{transaction_id}/vectors/{vector_id}",
+    tag = "transactions",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier"),
+        ("transaction_id" = u64, Path, description = "Transaction identifier"),
+        ("vector_id" = String, Path, description = "Vector identifier")
+    ),
+    responses(
+        (status = 204, description = "Vector deleted successfully"),
+        (status = 400, description = "Failed to delete vector"),
+        (status = 404, description = "Transaction or vector not found")
+    )
+)]
 pub(crate) async fn delete_vector_by_id(
     path: web::Path<(String, u64, String)>,
     ctx: web::Data<AppContext>,
@@ -101,6 +204,23 @@ pub(crate) async fn delete_vector_by_id(
     Ok(HttpResponse::NoContent().finish())
 }
 
+/// Upsert vectors in a transaction
+///
+/// Creates or updates multiple vectors in a single operation as part of an ongoing transaction.
+#[utoipa::path(
+    post,
+    path = "/vectordb/collections/{collection_id}/transactions/{transaction_id}/upsert",
+    tag = "transactions",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier"),
+        ("transaction_id" = u64, Path, description = "Transaction identifier")
+    ),
+    request_body = UpsertDto,
+    responses(
+        (status = 200, description = "Vectors upserted successfully"),
+        (status = 400, description = "Failed to upsert vectors")
+    )
+)]
 pub(crate) async fn upsert(
     path: web::Path<(String, u64)>,
     ctx: web::Data<AppContext>,

--- a/src/api/vectordb/transactions/dtos.rs
+++ b/src/api/vectordb/transactions/dtos.rs
@@ -1,14 +1,16 @@
 use crate::api::vectordb::vectors::dtos::CreateVectorDto;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Serialize)]
-pub(crate) struct CreateTransactionResponseDto {
+#[derive(Serialize, ToSchema)]
+pub struct CreateTransactionResponseDto {
     pub transaction_id: String,
+    #[schema(value_type = String, example = "2023-01-01T12:00:00Z")]
     pub created_at: DateTime<Utc>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, ToSchema)]
 pub struct UpsertDto {
     pub vectors: Vec<CreateVectorDto>,
 }

--- a/src/api/vectordb/transactions/mod.rs
+++ b/src/api/vectordb/transactions/mod.rs
@@ -1,5 +1,5 @@
-mod controller;
-pub(super) mod dtos;
+pub mod controller;
+pub mod dtos;
 pub(super) mod error;
 mod repo;
 mod service;

--- a/src/api/vectordb/vectors/controller.rs
+++ b/src/api/vectordb/vectors/controller.rs
@@ -1,6 +1,6 @@
 use actix_web::{web, HttpResponse, Result};
 
-use super::dtos::VectorsQueryDto;
+use super::dtos::{CreateVectorDto, SimilarVector, VectorsQueryDto};
 use super::{error::VectorsError, service};
 
 use crate::models::collection_cache::CollectionCacheExt;
@@ -9,6 +9,23 @@ use crate::{
     models::{common::WaCustomError, types::VectorId},
 };
 
+/// Get vectors for a document
+///
+/// Returns all vectors associated with a specific document ID within a collection.
+#[utoipa::path(
+    get,
+    path = "/collections/{collection_id}/vectors",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier"),
+    ),
+    responses(
+        (status = 200, description = "List of vectors", body = [CreateVectorDto]),
+        (status = 400, description = "Bad request"),
+        (status = 404, description = "Collection not found"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "vectors"
+)]
 pub(crate) async fn query_vectors(
     collection_id: web::Path<String>,
     web::Query(query): web::Query<VectorsQueryDto>,
@@ -25,6 +42,24 @@ pub(crate) async fn query_vectors(
     Ok(HttpResponse::Ok().json(vectors))
 }
 
+/// Get a specific vector by ID
+///
+/// Returns a vector with the specified ID from a collection.
+#[utoipa::path(
+    get,
+    path = "/vectordb/collections/{collection_id}/vectors/{vector_id}",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier"),
+        ("vector_id" = String, Path, description = "Vector identifier")
+    ),
+    responses(
+        (status = 200, description = "The requested vector", body = CreateVectorDto),
+        (status = 400, description = "Bad request"),
+        (status = 404, description = "Vector not found"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "vectors"
+)]
 pub(crate) async fn get_vector_by_id(
     path: web::Path<(String, String)>,
     ctx: web::Data<AppContext>,
@@ -40,6 +75,23 @@ pub(crate) async fn get_vector_by_id(
     Ok(HttpResponse::Ok().json(vector))
 }
 
+/// Check if a vector exists
+///
+/// Returns 200 OK if the vector exists, 404 if it doesn't.
+#[utoipa::path(
+    head,
+    path = "/vectordb/collections/{collection_id}/vectors/{vector_id}",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier"),
+        ("vector_id" = String, Path, description = "Vector identifier")
+    ),
+    responses(
+        (status = 200, description = "Vector exists"),
+        (status = 404, description = "Vector not found"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "vectors"
+)]
 pub(crate) async fn check_vector_existence(
     path: web::Path<(String, String)>,
     ctx: web::Data<AppContext>,
@@ -67,6 +119,24 @@ pub(crate) async fn check_vector_existence(
     }
 }
 
+/// Fetch similar vectors (neighbors) for a specific vector
+///
+/// Returns vectors that are similar to the specified vector ID.
+#[utoipa::path(
+    get,
+    path = "/vectordb/collections/{collection_id}/vectors/{vector_id}/neighbors",
+    params(
+        ("collection_id" = String, Path, description = "Collection identifier"),
+        ("vector_id" = String, Path, description = "Vector identifier")
+    ),
+    responses(
+        (status = 200, description = "List of similar vectors", body = [SimilarVector]),
+        (status = 400, description = "Bad request"),
+        (status = 404, description = "Vector not found"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "vectors"
+)]
 pub(crate) async fn fetch_vector_neighbors(
     path: web::Path<(String, String)>,
     ctx: web::Data<AppContext>,

--- a/src/api/vectordb/vectors/dtos.rs
+++ b/src/api/vectordb/vectors/dtos.rs
@@ -12,17 +12,23 @@ use serde::{
 
 use crate::{indexes::inverted::types::SparsePair, models::types::VectorId};
 
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
 pub struct VectorsQueryDto {
+    #[schema(value_type = String, example = "doc123")]
     pub document_id: DocumentId,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, utoipa::ToSchema)]
 pub(crate) struct CreateVectorDto {
+    #[schema(value_type = String)]
     pub id: VectorId,
+    #[schema(value_type = String, nullable = true)]
     pub document_id: Option<DocumentId>,
+    #[schema(example = "[0.1, 0.2, 0.3]")]
     pub dense_values: Option<Vec<f32>>,
+    #[schema(value_type = Object, nullable = true)]
     pub metadata: Option<MetadataFields>,
+    #[schema(value_type = Object, nullable = true)]
     pub sparse_values: Option<Vec<SparsePair>>,
     pub text: Option<String>,
 }
@@ -181,8 +187,9 @@ impl<'de> Deserialize<'de> for CreateVectorDto {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, utoipa::ToSchema)]
 pub(crate) struct SimilarVector {
+    #[schema(value_type = String)]
     pub id: VectorId,
     pub score: f32,
 }

--- a/src/api/vectordb/vectors/mod.rs
+++ b/src/api/vectordb/vectors/mod.rs
@@ -1,6 +1,6 @@
 use actix_web::{web, Scope};
 
-mod controller;
+pub mod controller;
 pub(crate) mod dtos;
 pub(crate) mod error;
 pub(crate) mod repo;

--- a/src/api/vectordb/versions/controller.rs
+++ b/src/api/vectordb/versions/controller.rs
@@ -1,28 +1,74 @@
 use super::service;
 use crate::app_context::AppContext;
 use actix_web::{web, HttpResponse, Result};
+use super::dtos::{VersionListResponse, CurrentVersionResponse};
+use super::error::VersionError;
 
+/// List all versions of a collection
+#[utoipa::path(
+    get,
+    path = "/vectordb/collections/{collection_id}/versions",
+    tag = "versions",
+    params(
+        ("collection_id" = String, Path, description = "ID of the collection")
+    ),
+    responses(
+        (status = 200, description = "List of collection versions", body = VersionListResponse),
+        (status = 404, description = "Collection not found"),
+        (status = 500, description = "Database error")
+    )
+)]
 pub(crate) async fn list_versions(
     collection_id: web::Path<String>,
     ctx: web::Data<AppContext>,
-) -> Result<HttpResponse> {
+) -> Result<HttpResponse, VersionError> {
     let versions = service::list_versions(ctx.into_inner(), &collection_id).await?;
     Ok(HttpResponse::Ok().json(versions))
 }
 
+/// Get the current version of a collection
+#[utoipa::path(
+    get,
+    path = "/vectordb/collections/{collection_id}/versions/current",
+    tag = "versions",
+    params(
+        ("collection_id" = String, Path, description = "ID of the collection")
+    ),
+    responses(
+        (status = 200, description = "Current collection version", body = CurrentVersionResponse),
+        (status = 404, description = "Collection not found"),
+        (status = 500, description = "Database error")
+    )
+)]
 pub(crate) async fn get_current_version(
     collection_id: web::Path<String>,
     ctx: web::Data<AppContext>,
-) -> Result<HttpResponse> {
+) -> Result<HttpResponse, VersionError> {
     let current_version = service::get_current_version(ctx.into_inner(), &collection_id).await?;
     Ok(HttpResponse::Ok().json(current_version))
 }
 
+/// Set the current version of a collection
+#[utoipa::path(
+    put,
+    path = "/vectordb/collections/{collection_id}/versions/current/{version_hash}",
+    tag = "versions",
+    params(
+        ("collection_id" = String, Path, description = "ID of the collection"),
+        ("version_hash" = String, Path, description = "Hash of the version to set as current")
+    ),
+    responses(
+        (status = 200, description = "Version set as current successfully"),
+        (status = 400, description = "Invalid version hash"),
+        (status = 404, description = "Collection not found"),
+        (status = 500, description = "Database error")
+    )
+)]
 #[allow(unused)]
 pub(crate) async fn set_current_version(
     path: web::Path<(String, String)>,
     ctx: web::Data<AppContext>,
-) -> Result<HttpResponse> {
+) -> Result<HttpResponse, VersionError> {
     let (collection_id, version_hash) = path.into_inner();
     service::set_current_version(ctx.into_inner(), &collection_id, &version_hash).await?;
     Ok(HttpResponse::Ok().finish())

--- a/src/api/vectordb/versions/dtos.rs
+++ b/src/api/vectordb/versions/dtos.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::models::versioning::{Timestamp, VersionHash, VersionNumber};
 
-#[derive(Serialize)]
+#[derive(Serialize, utoipa::ToSchema)]
 pub struct VersionMetadata {
     pub hash: VersionHash,
     pub version_number: VersionNumber,
@@ -10,13 +10,13 @@ pub struct VersionMetadata {
     pub vector_count: u64,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, utoipa::ToSchema)]
 pub struct VersionListResponse {
     pub versions: Vec<VersionMetadata>,
     pub current_hash: VersionHash,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, utoipa::ToSchema)]
 pub struct CurrentVersionResponse {
     pub hash: VersionHash,
     pub version_number: VersionNumber,

--- a/src/api/vectordb/versions/mod.rs
+++ b/src/api/vectordb/versions/mod.rs
@@ -1,6 +1,6 @@
 use actix_web::{web, Scope};
 
-mod controller;
+pub mod controller;
 pub(crate) mod dtos;
 mod error;
 mod service;

--- a/src/models/collection.rs
+++ b/src/models/collection.rs
@@ -26,24 +26,25 @@ use siphasher::sip::SipHasher24;
 use std::fs::create_dir_all;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::{fs, hash::Hasher, path::Path, sync::Arc};
+use utoipa::ToSchema;
 
-#[derive(Deserialize, Clone, Serialize, Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct DenseVectorOptions {
     pub enabled: bool,
     pub dimension: usize,
 }
 
-#[derive(Deserialize, Clone, Serialize, Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct SparseVectorOptions {
     pub enabled: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct TFIDFOptions {
     pub enabled: bool,
 }
 
-#[derive(Deserialize, Clone, Serialize, Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct CollectionConfig {
     pub max_vectors: Option<u32>,
     pub replication_factor: Option<u32>,

--- a/src/models/collection_transaction.rs
+++ b/src/models/collection_transaction.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
+use utoipa::ToSchema;
 
 use crate::{config_loader::Config, indexes::IndexOps};
 
@@ -95,22 +96,25 @@ impl CollectionTransaction {
 
 const NOT_STARTED_MESSAGE: &str = "Indexing has not started yet.";
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ToSchema)]
 pub enum TransactionStatus {
     NotStarted {
+        #[schema(value_type = String, example = "2023-01-01T12:00:00Z")]
         last_updated: DateTime<Utc>,
     },
     InProgress {
         progress: Progress,
+        #[schema(value_type = String, example = "2023-01-01T12:00:00Z")]
         last_updated: DateTime<Utc>,
     },
     Complete {
         summary: Summary,
+        #[schema(value_type = String, example = "2023-01-01T12:00:00Z")]
         last_updated: DateTime<Utc>,
     },
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
 pub struct Progress {
     pub percentage_done: f32,
     pub records_indexed: u32,
@@ -119,7 +123,7 @@ pub struct Progress {
     pub estimated_time_remaining_seconds: u32,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
 pub struct Summary {
     pub total_records_indexed: u32,
     pub duration_seconds: u32,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -21,6 +21,7 @@ pub mod paths;
 pub mod prob_lazy_load;
 pub mod prob_node;
 pub mod rpc;
+pub mod schema_traits;
 pub mod serializer;
 pub mod sparse_ann_query;
 pub mod tf_idf_index;

--- a/src/models/schema_traits.rs
+++ b/src/models/schema_traits.rs
@@ -1,0 +1,36 @@
+use utoipa::ToSchema;
+use serde::{Deserialize, Serialize};
+use crate::models::types::DistanceMetric;
+
+// Create a wrapper type for DistanceMetric that can derive ToSchema
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DistanceMetricSchema {
+    Cosine,
+    Euclidean,
+    Hamming,
+    DotProduct,
+}
+
+// Implement From and Into traits to convert between the wrapper and real type
+impl From<DistanceMetric> for DistanceMetricSchema {
+    fn from(metric: DistanceMetric) -> Self {
+        match metric {
+            DistanceMetric::Cosine => DistanceMetricSchema::Cosine,
+            DistanceMetric::Euclidean => DistanceMetricSchema::Euclidean,
+            DistanceMetric::Hamming => DistanceMetricSchema::Hamming,
+            DistanceMetric::DotProduct => DistanceMetricSchema::DotProduct,
+        }
+    }
+}
+
+impl From<DistanceMetricSchema> for DistanceMetric {
+    fn from(schema: DistanceMetricSchema) -> Self {
+        match schema {
+            DistanceMetricSchema::Cosine => DistanceMetric::Cosine,
+            DistanceMetricSchema::Euclidean => DistanceMetric::Euclidean,
+            DistanceMetricSchema::Hamming => DistanceMetric::Hamming,
+            DistanceMetricSchema::DotProduct => DistanceMetric::DotProduct,
+        }
+    }
+}

--- a/src/models/versioning.rs
+++ b/src/models/versioning.rs
@@ -7,6 +7,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use twox_hash::XxHash32;
+use utoipa::ToSchema;
 
 use super::tree_map::TreeMapKey;
 
@@ -27,7 +28,8 @@ impl Deref for BranchId {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, ToSchema)]
+#[schema(value_type = i32, description = "Version number")]
 pub struct VersionNumber(u32);
 
 impl From<u32> for VersionNumber {
@@ -44,7 +46,8 @@ impl Deref for VersionNumber {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, ToSchema)]
+#[schema(value_type = i64, description = "Timestamp in milliseconds since epoch")]
 pub struct Timestamp(pub u128);
 
 impl From<u128> for Timestamp {
@@ -61,7 +64,8 @@ impl Deref for Timestamp {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[schema(value_type = i64, description = "Version hash identifier")]
 pub struct VersionHash(u64);
 
 impl From<u64> for VersionHash {
@@ -525,6 +529,8 @@ impl VersionControl {
             .collect())
     }
 }
+
+
 
 #[cfg(test)]
 mod tests {

--- a/src/web_server.rs
+++ b/src/web_server.rs
@@ -1,4 +1,5 @@
 use crate::api::auth::{auth_module, authentication_middleware::AuthenticationMiddleware};
+use crate::api::docs::api_docs_module;
 use crate::api::vectordb::collections::collections_module;
 use crate::api::vectordb::indexes::indexes_module;
 use crate::api::vectordb::search::search_module;
@@ -51,6 +52,7 @@ pub async fn run_actix_server_with_context(ctx: Data<AppContext>) -> std::io::Re
             // register simple handler, handle all methods
             .app_data(web::JsonConfig::default().limit(8_388_608)) // 8 MB)
             .app_data(ctx.clone())
+            .service(api_docs_module())
             .service(auth_module())
             .service(
                 web::scope("/vectordb")


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

This pull request introduces OpenAPI specification generation for several key API endpoints. The `openapi.json` is generated by `utoipa` at compile time. This will improve API discoverability and make it easier for developers to understand and integrate with the API.

Changes:

Implemented OpenAPI spec generation for the following endpoint groups:
`/auth`
`/vectordb/collections`
`/vectordb/indexes`
`/vectordb/search`
`/vectordb/vectors`
`/vectordb/versions`
`/vectordb/transactions`
`/vectordb/sync_transactions`

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR does not contain any unnecessary/auto generated code changes.
- [x] The PR is made from a branch that's **not** called "main" and is up-to-date with "main".
- [x] The PR is **assigned** to the appropriate reviewers 

@anandwana001 @tinkn  Could you please review this when you have a moment? Thank you!

generated [`openapi.json`](https://github.com/user-attachments/files/20196729/cosdata-openapi.json) 
