### PR TITLE
Use separate root nodes in hnsw index for metadata filtering

### DIFF
--- a/src/api/vectordb/vectors/repo.rs
+++ b/src/api/vectordb/vectors/repo.rs
@@ -40,8 +40,7 @@ pub(crate) async fn query_vectors(
     internal_ids
         .map(|internal_id| {
             Ok(collection
-                .internal_to_external_map
-                .get_latest(internal_id)
+                .get_raw_emb_by_internal_id(internal_id)
                 .ok_or(VectorsError::NotFound)?
                 .clone()
                 .into())
@@ -64,8 +63,7 @@ pub(crate) async fn get_vector_by_id(
         .get_latest(&vector_id)
         .ok_or(VectorsError::NotFound)?;
     let vector = collection
-        .internal_to_external_map
-        .get_latest(internal_id)
+        .get_raw_emb_by_internal_id(internal_id)
         .ok_or(VectorsError::NotFound)?
         .clone();
     Ok(vector.into())
@@ -97,10 +95,7 @@ pub(crate) async fn check_vector_existence(
         } else {
             return Ok(false);
         };
-    Ok(collection
-        .internal_to_external_map
-        .get_latest(internal_id)
-        .is_some())
+    Ok(collection.get_raw_emb_by_internal_id(internal_id).is_some())
 }
 
 pub(crate) async fn fetch_vector_neighbors(

--- a/src/api_service.rs
+++ b/src/api_service.rs
@@ -139,6 +139,8 @@ pub async fn init_hnsw_index_for_collection(
 
     let hnsw_index = Arc::new(HNSWIndex::new(
         root,
+        // @TODO(vineet) Add pseudo root node
+        None,
         lp,
         collection.meta.dense_vector.dimension,
         quantization_metric,

--- a/src/api_service.rs
+++ b/src/api_service.rs
@@ -199,8 +199,7 @@ pub async fn init_hnsw_index_for_collection(
         let num_dims = collection.meta.dense_vector.dimension;
         let pseudo_vals = pseudo_node_vector(num_dims);
         // base id for nonroot pseudo nodes is 1 more than the pseudo node
-        let pseudo_nonroot_base_id = pseudo_root_id().inc();
-        let pseudo_vec = DenseInputEmbedding(pseudo_nonroot_base_id, pseudo_vals, None, true);
+        let pseudo_vec = DenseInputEmbedding(pseudo_root_id(), pseudo_vals, None, true);
         let version_number = *collection.current_version.read();
         let transaction = BackgroundCollectionTransaction::from_version_id_and_number(
             &collection,

--- a/src/grpc/vectors/mod.rs
+++ b/src/grpc/vectors/mod.rs
@@ -47,8 +47,7 @@ crate::cfg_grpc! {
                 .get_latest(&VectorId::from(req.vector_id))
                 .ok_or_else(|| Status::not_found("Vector not found"))?;
             let vector = collection
-                .internal_to_external_map
-                .get_latest(internal_id)
+                .get_raw_emb_by_internal_id(internal_id)
                 .ok_or_else(|| Status::not_found("Vector not found"))?
                 .clone();
 

--- a/src/indexes/hnsw/mod.rs
+++ b/src/indexes/hnsw/mod.rs
@@ -46,6 +46,7 @@ pub struct HNSWIndexData {
     pub levels_prob: Vec<(f64, u8)>,
     pub dim: usize,
     pub root_vec_ptr_offset: FileOffset,
+    pub pseudo_root_vec_ptr_offset: Option<FileOffset>,
     pub quantization_metric: QuantizationMetric,
     pub distance_metric: DistanceMetric,
     pub storage_type: StorageType,
@@ -54,6 +55,7 @@ pub struct HNSWIndexData {
 
 pub struct HNSWIndex {
     pub root_vec: SharedLatestNode,
+    pub pseudo_root_vec: Option<SharedLatestNode>,
     pub levels_prob: Vec<(f64, u8)>,
     pub dim: usize,
     pub quantization_metric: RwLock<QuantizationMetric>,
@@ -93,6 +95,7 @@ impl HNSWIndex {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         root_vec: SharedLatestNode,
+        pseudo_root_vec: Option<SharedLatestNode>,
         levels_prob: Vec<(f64, u8)>,
         dim: usize,
         quantization_metric: QuantizationMetric,
@@ -108,6 +111,7 @@ impl HNSWIndex {
     ) -> Self {
         Self {
             root_vec,
+            pseudo_root_vec,
             levels_prob,
             dim,
             quantization_metric: RwLock::new(quantization_metric),
@@ -130,9 +134,19 @@ impl HNSWIndex {
         self.root_vec
     }
 
+    pub fn get_pseudo_root_vec(&self) -> Option<SharedLatestNode> {
+        self.pseudo_root_vec
+    }
+
     /// Returns FileIndex (offset) corresponding to the root node.
     pub fn root_vec_ptr_offset(&self) -> FileOffset {
         unsafe { &*self.root_vec }.file_offset
+    }
+
+    /// Returns FileIndex (offset) corresponding to the pseudo root node.
+    pub fn pseudo_root_vec_ptr_offset(&self) -> Option<FileOffset> {
+        let node = unsafe { self.get_pseudo_root_vec().map(|node| &*node) };
+        node.map(|n| n.file_offset)
     }
 }
 
@@ -302,11 +316,13 @@ impl IndexOps for HNSWIndex {
 
     fn get_data(&self) -> Self::Data {
         let offset = self.root_vec_ptr_offset();
+        let offset_pseudo = self.pseudo_root_vec_ptr_offset();
         Self::Data {
             hnsw_params: self.hnsw_params.read().unwrap().clone(),
             levels_prob: self.levels_prob.clone(),
             dim: self.dim,
             root_vec_ptr_offset: offset,
+            pseudo_root_vec_ptr_offset: offset_pseudo,
             quantization_metric: self.quantization_metric.read().unwrap().clone(),
             distance_metric: *self.distance_metric.read().unwrap(),
             storage_type: *self.storage_type.read().unwrap(),

--- a/src/indexes/hnsw/mod.rs
+++ b/src/indexes/hnsw/mod.rs
@@ -160,6 +160,8 @@ impl IndexOps for HNSWIndex {
     type Data = HNSWIndexData;
 
     fn validate_embedding(&self, embedding: Self::IndexingInput) -> Result<(), WaCustomError> {
+        // @TODO(vineet): Add validation for metadata fields (if
+        // applicable)
         if embedding.1.len() == self.dim {
             Ok(())
         } else {
@@ -356,7 +358,7 @@ impl IndexOps for HNSWIndex {
 
         let query_filter_dims = query.1.as_ref().map(|filter| {
             let metadata_schema = collection.meta.metadata_schema.as_ref().unwrap();
-            filter_encoded_dimensions(metadata_schema, &filter).unwrap()
+            filter_encoded_dimensions(metadata_schema, filter).unwrap()
         });
 
         let root_node = if query.1.is_some() {

--- a/src/indexes/inverted/mod.rs
+++ b/src/indexes/inverted/mod.rs
@@ -312,8 +312,7 @@ fn finalize_sparse_ann_results(
         let internal_id = InternalId::from(result.vector_id);
 
         let raw_embedding_ref = collection
-            .internal_to_external_map
-            .get_latest(&internal_id)
+            .get_raw_emb_by_internal_id(&internal_id)
             .ok_or_else(|| WaCustomError::NotFound("raw embedding not found".to_string()))?;
 
         let sparse_pairs = raw_embedding_ref.sparse_values.clone().ok_or_else(|| {

--- a/src/indexes/mod.rs
+++ b/src/indexes/mod.rs
@@ -217,8 +217,7 @@ pub trait IndexOps: Send + Sync {
                     (id, document_id, score, text)
                 } else {
                     let raw_emb = collection
-                        .internal_to_external_map
-                        .get_latest(&internal_id)
+                        .get_raw_emb_by_internal_id(&internal_id)
                         .ok_or_else(|| {
                             WaCustomError::NotFound("raw embedding not found".to_string())
                         })?

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -208,8 +208,7 @@ pub fn pseudo_level_probs(num_levels: u8, num_pseudo_nodes: u16) -> Vec<(f64, u8
 
 /// Returns vector values for pseudo node
 pub fn pseudo_node_vector(num_dims: usize) -> Vec<f32> {
-    // @TODO(vineet): All 0s instead of all 1s
-    vec![1.0; num_dims]
+    vec![0.0; num_dims]
 }
 
 /// Returns the internal id for pseudo root node

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -121,6 +121,10 @@ impl<'de> Deserialize<'de> for FieldValue {
 
 pub type MetadataFields = HashMap<FieldName, FieldValue>;
 
+/// Returns metadata dimensions based on the fields
+///
+/// Note that the base dimensions will be implicitly included as the
+/// first item in the returned vector
 pub fn fields_to_dimensions(
     schema: &MetadataSchema,
     metadata_fields: Option<&MetadataFields>,

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -14,6 +14,7 @@ pub use query_filtering::{Filter, Operator, Predicate, QueryFilterDimensions};
 pub use schema::MetadataSchema;
 
 use crate::models::common::generate_level_probs;
+use crate::models::types::InternalId;
 
 pub const HIGH_WEIGHT: i32 = 1;
 
@@ -203,6 +204,21 @@ pub fn pseudo_level_probs(num_levels: u8, num_pseudo_nodes: u16) -> Vec<(f64, u8
         result.push((0.0, i));
     }
     result
+}
+
+/// Returns vector values for pseudo node
+pub fn pseudo_node_vector(num_dims: usize) -> Vec<f32> {
+    // @TODO(vineet): All 0s instead of all 1s
+    vec![1.0; num_dims]
+}
+
+/// Returns the internal id for pseudo root node
+pub fn pseudo_root_id() -> InternalId {
+    // The last 258 IDs in the generate u32 internal IDs range are
+    // reserved for special cases, `u32::MAX` is for root node,
+    // `u32::MAX - 1` is for queries, and the range `[u32::MAX -
+    // 257, u32::MAX - 2]`
+    InternalId::from(u32::MAX - 257)
 }
 
 #[cfg(test)]

--- a/src/models/common.rs
+++ b/src/models/common.rs
@@ -1,7 +1,7 @@
 use super::buffered_io::BufIoError;
 use super::cache_loader::HNSWIndexCache;
 use super::prob_node::SharedLatestNode;
-use super::types::{InternalId, MetricResult};
+use super::types::{InternalId, MetricResult, ReplicaNodeKind};
 use crate::distance::DistanceError;
 use crate::indexes::hnsw::HNSWIndex;
 use crate::metadata;
@@ -379,7 +379,7 @@ pub fn get_max_insert_level(x: f64, levels: &[(f64, u8)]) -> u8 {
 }
 
 pub fn remove_duplicates_and_filter(
-    hnsw_index: &HNSWIndex,
+    _hnsw_index: &HNSWIndex,
     vec: Vec<(SharedLatestNode, MetricResult)>,
     k: Option<usize>,
     cache: &HNSWIndexCache,
@@ -391,11 +391,13 @@ pub fn remove_duplicates_and_filter(
             let lazy_item = unsafe { &*lazy_item_latest_ptr }.latest();
             let node = unsafe { &**lazy_item }.try_get_data(cache).unwrap();
             let replica_id = node.get_id();
-            let orig_id = replica_id / (hnsw_index.max_replica_per_node as u32);
-            if !seen.insert(orig_id) {
+            if !seen.insert(replica_id) {
                 return None;
             }
             if *replica_id == u32::MAX {
+                return None;
+            }
+            if let ReplicaNodeKind::Pseudo = node.replica_node_kind() {
                 return None;
             }
             Some((replica_id, similarity))

--- a/src/models/file_persist.rs
+++ b/src/models/file_persist.rs
@@ -109,14 +109,19 @@ pub fn read_prop_value_from_file(
 
 #[derive(Deserialize, Serialize)]
 struct NodePropMetadataSerde {
+    pub replica_id: InternalId,
     pub vec: Arc<Metadata>,
 }
 
 pub fn write_prop_metadata_to_file(
+    replica_id: InternalId,
     vec: Arc<Metadata>,
     file: &mut File,
 ) -> Result<(FileOffset, BytesToRead), WaCustomError> {
-    let prop_metadata = NodePropMetadataSerde { vec: vec.clone() };
+    let prop_metadata = NodePropMetadataSerde {
+        replica_id,
+        vec: vec.clone(),
+    };
     let prop_bytes = serde_cbor::to_vec(&prop_metadata)
         .map_err(|e| WaCustomError::SerializationError(e.to_string()))?;
 
@@ -145,6 +150,7 @@ pub fn read_prop_metadata_from_file(
         .map_err(|e| BufIoError::Io(io::Error::new(io::ErrorKind::InvalidData, e.to_string())))?;
 
     Ok(NodePropMetadata {
+        replica_id: prop_metadata.replica_id,
         vec: prop_metadata.vec,
         location: (offset, bytes_to_read),
     })

--- a/src/models/prob_node.rs
+++ b/src/models/prob_node.rs
@@ -216,7 +216,10 @@ impl ProbNode {
     }
 
     pub fn get_id(&self) -> InternalId {
-        self.prop_value.id
+        match &self.prop_metadata {
+            Some(metadata) => metadata.replica_id,
+            None => self.prop_value.id,
+        }
     }
 
     pub fn freeze(&self) -> RwLockReadGuard<'_, (u8, MetricResult)> {

--- a/src/models/prob_node.rs
+++ b/src/models/prob_node.rs
@@ -21,7 +21,7 @@ use super::{
     serializer::hnsw::RawDeserialize,
     types::{
         DistanceMetric, FileOffset, HNSWLevel, InternalId, MetricResult, NodePropMetadata,
-        NodePropValue,
+        NodePropValue, ReplicaNodeKind, VectorData,
     },
     versioning::VersionNumber,
 };
@@ -488,6 +488,18 @@ impl ProbNode {
             child,
             *cache.distance_metric.read().unwrap(),
         ))
+    }
+
+    /// Returns the kind of node it is
+    pub fn replica_node_kind(&self) -> ReplicaNodeKind {
+        let metadata = self.prop_metadata.as_ref().map(|pm| &*pm.vec);
+        let internal_id = self.get_id();
+        let vector_data = VectorData {
+            id: Some(&internal_id),
+            quantized_vec: &self.prop_value.vec,
+            metadata,
+        };
+        vector_data.replica_node_kind()
     }
 }
 

--- a/src/models/types.rs
+++ b/src/models/types.rs
@@ -899,7 +899,7 @@ impl CollectionsMap {
                     pseudo_root,
                 );
                 let pseudo_root_ptr = LatestNode::new(pseudo_root, pseudo_root_ptr_offset);
-                latest_version_links.insert(root_ptr_offset, root_ptr);
+                latest_version_links.insert(pseudo_root_ptr_offset, pseudo_root_ptr);
                 bufman.close_cursor(cursor)?;
                 Some(pseudo_root_ptr)
             }

--- a/src/models/types.rs
+++ b/src/models/types.rs
@@ -293,6 +293,15 @@ impl TreeMapKey for DocumentId {
 )]
 pub struct InternalId(u32);
 
+impl InternalId {
+    /// Increments an InternalId by 1 and returns a new instance
+    ///
+    /// The caller needs to ensure it doesn't result in overflow
+    pub fn inc(&self) -> Self {
+        InternalId::from(self.0 + 1)
+    }
+}
+
 impl From<u32> for InternalId {
     fn from(id: u32) -> Self {
         Self(id)

--- a/src/models/types.rs
+++ b/src/models/types.rs
@@ -159,11 +159,42 @@ pub struct NodePropMetadata {
     pub location: PropPersistRef,
 }
 
+/// Kinds of nodes in the HNSW/dense index
+///
+/// They are called 'replica nodes' because when metadata fields are
+/// supported by the index, one embedding may result in multiple nodes
+/// getting added to the HNSW graph.
 #[derive(Debug)]
 pub enum ReplicaNodeKind {
+    /// These are "static" nodes created at the time of index
+    /// initialization under the pseudo root node (See `RootNodeKind`
+    /// for more types of root nodes)
     Pseudo,
+    /// Nodes corresponding to the vector embeddings with metadata
+    /// dimensions either absent or default value (all 0s)
     Base,
+    /// Nodes corresponding to the vector embeddings with metadata
+    /// dimensions set
     Metadata,
+}
+
+impl ReplicaNodeKind {
+    /// Returns the kind of root node that this kind of replica must
+    /// be indexed under
+    pub fn root_node_kind(&self) -> RootNodeKind {
+        match self {
+            Self::Pseudo => RootNodeKind::Pseudo,
+            Self::Base => RootNodeKind::Main,
+            Self::Metadata => RootNodeKind::Pseudo,
+        }
+    }
+}
+
+/// Kinds of root nodes in HNSW/dense index
+#[derive(Debug)]
+pub enum RootNodeKind {
+    Pseudo,
+    Main,
 }
 
 #[derive(Debug)]

--- a/src/models/types.rs
+++ b/src/models/types.rs
@@ -155,6 +155,7 @@ pub struct MetadataId(pub u8);
 
 #[derive(Debug, PartialEq)]
 pub struct NodePropMetadata {
+    pub replica_id: InternalId,
     pub vec: Arc<Metadata>,
     pub location: PropPersistRef,
 }

--- a/src/vector_store.rs
+++ b/src/vector_store.rs
@@ -416,8 +416,7 @@ pub fn finalize_ann_results(
 
     for (internal_id, _) in filtered {
         let raw_emb = collection
-            .internal_to_external_map
-            .get_latest(&internal_id)
+            .get_raw_emb_by_internal_id(&internal_id)
             .ok_or_else(|| {
                 WaCustomError::NotFound(format!("raw embedding not found for id={internal_id:?}"))
             })?;

--- a/src/vector_store.rs
+++ b/src/vector_store.rs
@@ -443,10 +443,17 @@ impl IndexableEmbedding {
     fn node_kind(&self) -> ReplicaNodeKind {
         if self.overridden_level_probs.is_some() {
             ReplicaNodeKind::Pseudo
-        } else if self.prop_metadata.is_some() {
-            ReplicaNodeKind::Metadata
         } else {
-            ReplicaNodeKind::Base
+            match &self.prop_metadata {
+                Some(m) => {
+                    if m.vec.mag == 0.0 {
+                        ReplicaNodeKind::Base
+                    } else {
+                        ReplicaNodeKind::Metadata
+                    }
+                },
+                None => ReplicaNodeKind::Base,
+            }
         }
     }
 

--- a/tests/test_metadata_filters.py
+++ b/tests/test_metadata_filters.py
@@ -23,6 +23,7 @@ import json
 import random
 import numpy as np
 from functools import partial
+import time
 
 
 token = None
@@ -103,7 +104,7 @@ def gen_vectors(num, vcoll):
         vid = i + 1
         values = np.random.uniform(-1, 1, vcoll.num_dimensions).tolist()
         metadata = vcoll.gen_metadata_fields()
-        yield {"id": vid, "values": values, "metadata": metadata}
+        yield {"id": str(vid), "values": values, "metadata": metadata}
 
 
 def create_transaction(collection_name: str) -> str:
@@ -535,6 +536,9 @@ def cmd_insert_and_check(ctx, args):
 
         tcs = vcoll.test_cases(vidx)
 
+        # Wait for 10s for background indexing before running search
+        # queries
+        time.sleep(10)
         print("Running search queries")
         search_and_compare(db_name, tcs)
 
@@ -542,7 +546,7 @@ def cmd_insert_and_check(ctx, args):
 def cmd_query(ctx, args):
     vec_id = args.vector_id
     vec = get_vector_by_id(ctx["vector_db_name"], vec_id)
-    values = vec["values"]
+    values = vec["dense_values"]
     print("Vector metadata:", vec["metadata"])
     metadata_filter = json.loads(args.metadata_filter) if args.metadata_filter else None
     res = search_ann(ctx["vector_db_name"], values, metadata_filter)

--- a/tests/test_metadata_filters.py
+++ b/tests/test_metadata_filters.py
@@ -528,14 +528,15 @@ def cmd_insert_and_check(ctx, args):
     print("  Create index response:", create_index_response)
 
     num_to_insert = args.num_vecs
-    vectors = gen_vectors(num_to_insert, vcoll)
-    print(f"Inserting {num_to_insert} vectors")
-    vidx = insert_vectors(coll_id, vectors)
+    if num_to_insert > 0:
+        vectors = gen_vectors(num_to_insert, vcoll)
+        print(f"Inserting {num_to_insert} vectors")
+        vidx = insert_vectors(coll_id, vectors)
 
-    tcs = vcoll.test_cases(vidx)
+        tcs = vcoll.test_cases(vidx)
 
-    print("Running search queries")
-    search_and_compare(db_name, tcs)
+        print("Running search queries")
+        search_and_compare(db_name, tcs)
 
 
 def cmd_query(ctx, args):


### PR DESCRIPTION
WIP: This PR is not ready to be merged yet. Opening a PR for @a-rustacean to review. There's one issue which I am debugging with his help. 

## Explanation
This PR introduces another kind of root node in the HNSW index besides the original one (henceforth it's referred to as `main root node`). The new one is called `pseudo root node` and all metadata replica nodes will be created under the pseudo root node. The base nodes will be created under main root node. 

My deterministic tests are passing 100% - by deterministic tests I mean the search query vector is exactly the same as a previously inserted vector along with known metadata filters.

However, if the server is restarted after adding data, it crashes at the time of deserializing the prob node in the load_hnsw_index function call. I am debugging this. 

## Essential Checklist
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR does not contain any unnecessary/auto generated code changes.
- [x] The PR is made from a branch that's **not** called "main" and is up-to-date with "main".
- [x] The PR is **assigned** to the appropriate reviewers 

@a-rustacean  Could you please review this when you have a moment? Thank you!
