### PR TITLE
fix #330: replace hardcoded vector counts with dynamic calculation and caching system

### DIFF
--- a/src/models/collection_version_utils.rs
+++ b/src/models/collection_version_utils.rs
@@ -1,0 +1,201 @@
+use super::collection::Collection;
+use super::tree_map::UnsafeVersionedItem;
+use super::types::InternalId;
+use super::versioning::VersionNumber;
+
+/// Get the value from a versioned item chain at a specific version.
+///
+/// This function traverses the version chain of an `UnsafeVersionedItem` to find
+/// the most recent value that was committed at or before the given version number.
+///
+/// # Arguments
+/// * `versioned_item` - The head of the version chain to traverse
+/// * `target_version` - The version number to query for
+///
+/// # Returns
+/// * `Some(&T)` - The value that was current at the target version
+/// * `None` - If no value exists at or before the target version
+pub fn get_value_at_version<T>(
+    versioned_item: &UnsafeVersionedItem<T>,
+    target_version: VersionNumber,
+) -> Option<&T> {
+    // Start from the head of the chain (oldest version)
+    let mut current = versioned_item;
+    let mut result = None;
+
+    // Traverse the chain to find the latest value at or before target_version
+    loop {
+        // If this version is at or before our target, it's a candidate
+        if *current.version <= *target_version {
+            result = Some(&current.value);
+        } else {
+            // This version is after our target, so we can't use it
+            break;
+        }
+
+        // Move to the next version in the chain
+        match unsafe { &*current.next.get() } {
+            Some(next) => current = next,
+            None => break,
+        }
+    }
+
+    result
+}
+
+/// Fast O(1) vector count lookup using cached version-based counts
+pub fn count_live_vectors(collection: &Collection, version: VersionNumber) -> usize {
+    // Try cached count first - O(1)
+    if let Some(count) = collection.get_cached_vector_count(version) {
+        return count;
+    }
+
+    // Calculate incrementally and cache - O(versions_since_last_cache)
+    let count = count_live_vectors_incremental(collection, version);
+    collection.cache_vector_count(version, count);
+    count
+}
+
+/// Incremental counting that builds on previous cached counts
+fn count_live_vectors_incremental(collection: &Collection, target_version: VersionNumber) -> usize {
+    // Find the most recent cached count before our target
+    let (base_version, mut count) = collection.find_nearest_cached_count_before(target_version);
+
+    // Get versions between base and target
+    let versions_to_add = match collection.vcs.get_versions_starting_from_exclusive(base_version) {
+        Ok(versions) => versions
+            .into_iter()
+            .filter(|v| v.version <= target_version)
+            .map(|v| v.version)
+            .collect::<Vec<_>>(),
+        Err(_) => return count_live_vectors_by_range(collection, target_version),
+    };
+
+    // Add vectors from each intermediate version
+    for version in versions_to_add {
+        count += count_vectors_added_in_specific_version(collection, version);
+    }
+
+    count
+}
+
+/// Count vectors that were first added in a specific version (not cumulative)
+fn count_vectors_added_in_specific_version(collection: &Collection, version: VersionNumber) -> usize {
+    use std::sync::atomic::Ordering;
+
+    let mut count = 0;
+    let max_internal_id = collection.internal_id_counter.load(Ordering::Relaxed);
+
+    for internal_id in 0..max_internal_id {
+        let id = InternalId::from(internal_id);
+
+        if let Some(versioned_item) = collection.internal_to_external_map.get_versioned(&id) {
+            // Only count if this vector was first created in this exact version
+            if versioned_item.version == version {
+                count += 1;
+            }
+        }
+    }
+
+    count
+}
+
+/// Count live vectors using a brute-force approach by checking known internal IDs
+///
+/// This is the recommended implementation that works with the current TreeMap API.
+/// It checks each internal ID up to the current counter value.
+///
+/// # Arguments
+/// * `collection` - Reference to the collection to count vectors in
+/// * `version` - The version number to query for live vectors
+///
+/// # Returns
+/// * The number of unique live vectors at the specified version
+pub fn count_live_vectors_by_range(collection: &Collection, version: VersionNumber) -> usize {
+    use std::sync::atomic::Ordering;
+
+    let mut count = 0;
+    let max_internal_id = collection.internal_id_counter.load(Ordering::Relaxed);
+
+    // Debug logging
+    eprintln!(
+        "DEBUG count_live_vectors: collection={}, version={}, max_internal_id={}",
+        collection.meta.name, *version, max_internal_id
+    );
+
+    // Check each internal ID up to the maximum
+    for internal_id in 0..max_internal_id {
+        let id = InternalId::from(internal_id);
+
+        // Get the versioned item for this internal ID
+        if let Some(versioned_item) = collection.internal_to_external_map.get_versioned(&id) {
+            // Check if this vector exists at the target version
+            if get_value_at_version(versioned_item, version).is_some() {
+                eprintln!(
+                    "DEBUG: Found live vector at internal_id={}, version={}",
+                    internal_id, *version
+                );
+                count += 1;
+            }
+        }
+    }
+
+    eprintln!("DEBUG count_live_vectors: Final count={}", count);
+    count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::tree_map::UnsafeVersionedItem;
+
+    #[test]
+    fn test_get_value_at_version() {
+        // Create a version chain: v1 -> v3 -> v5
+        let item = UnsafeVersionedItem::new(VersionNumber::from(1), "value_v1");
+        item.insert(VersionNumber::from(3), "value_v3");
+        item.insert(VersionNumber::from(5), "value_v5");
+
+        // Test queries at different versions
+        assert_eq!(get_value_at_version(&item, VersionNumber::from(0)), None);
+        assert_eq!(
+            get_value_at_version(&item, VersionNumber::from(1)),
+            Some(&"value_v1")
+        );
+        assert_eq!(
+            get_value_at_version(&item, VersionNumber::from(2)),
+            Some(&"value_v1")
+        );
+        assert_eq!(
+            get_value_at_version(&item, VersionNumber::from(3)),
+            Some(&"value_v3")
+        );
+        assert_eq!(
+            get_value_at_version(&item, VersionNumber::from(4)),
+            Some(&"value_v3")
+        );
+        assert_eq!(
+            get_value_at_version(&item, VersionNumber::from(5)),
+            Some(&"value_v5")
+        );
+        assert_eq!(
+            get_value_at_version(&item, VersionNumber::from(10)),
+            Some(&"value_v5")
+        );
+    }
+
+    #[test]
+    fn test_get_value_at_version_single_item() {
+        let item = UnsafeVersionedItem::new(VersionNumber::from(5), "single_value");
+
+        assert_eq!(get_value_at_version(&item, VersionNumber::from(4)), None);
+        assert_eq!(
+            get_value_at_version(&item, VersionNumber::from(5)),
+            Some(&"single_value")
+        );
+        assert_eq!(
+            get_value_at_version(&item, VersionNumber::from(10)),
+            Some(&"single_value")
+        );
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -4,6 +4,7 @@ pub mod cache_loader;
 pub mod collection;
 pub mod collection_cache;
 pub mod collection_transaction;
+pub mod collection_version_utils;
 pub mod common;
 pub mod crypto;
 pub mod dot_product;

--- a/src/models/tree_map.rs
+++ b/src/models/tree_map.rs
@@ -578,6 +578,27 @@ impl TreeMapKey for u64 {
     }
 }
 
+impl TreeMapKey for usize {
+    fn key(&self) -> u64 {
+        *self as u64
+    }
+}
+
+impl super::serializer::SimpleSerialize for usize {
+    fn serialize(&self, bufman: &super::buffered_io::BufferManager, cursor: u64) -> Result<u32, super::buffered_io::BufIoError> {
+        let data = self.to_le_bytes();
+        Ok(bufman.write_to_end_of_file(cursor, &data)? as u32)
+    }
+
+    fn deserialize(bufman: &super::buffered_io::BufferManager, offset: super::types::FileOffset) -> Result<Self, super::buffered_io::BufIoError> {
+        let cursor = bufman.open_cursor()?;
+        bufman.seek_with_cursor(cursor, offset.0 as u64)?;
+        let value = bufman.read_u64_with_cursor(cursor)?;
+        bufman.close_cursor(cursor)?;
+        Ok(value as usize)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use tempfile::tempdir;

--- a/src/models/types.rs
+++ b/src/models/types.rs
@@ -610,6 +610,12 @@ impl CollectionsMap {
                 8192,
             );
 
+            let vector_count_cache_bufmans = BufferManagerFactory::new(
+                collections_path.clone(),
+                |root, part| root.join(format!("{}.vector_count_cache", part)),
+                8192,
+            );
+
             let id_counter_value = retrieve_highest_internal_id(&lmdb)?.unwrap_or_default();
 
             let collection = Arc::new(Collection {
@@ -635,6 +641,10 @@ impl CollectionsMap {
                     config.tree_map_serialized_parts,
                 )?,
                 internal_id_counter: AtomicU32::new(id_counter_value),
+                vector_count_cache: TreeMap::deserialize(
+                    vector_count_cache_bufmans,
+                    config.tree_map_serialized_parts,
+                )?,
                 hnsw_index: parking_lot::RwLock::new(hnsw_index),
                 inverted_index: parking_lot::RwLock::new(inverted_index),
                 tf_idf_index: parking_lot::RwLock::new(tf_idf_index),

--- a/src/models/versioning.rs
+++ b/src/models/versioning.rs
@@ -8,7 +8,7 @@ use utoipa::ToSchema;
 
 use super::tree_map::TreeMapKey;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, ToSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, ToSchema)]
 #[schema(value_type = i32, description = "Version number")]
 pub struct VersionNumber(u32);
 


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #330 
Previously, the version API endpoints were returning hardcoded zero values for vector counts, making version tracking useless for monitoring collection growth and state changes over time.

- Add dynamic vector count calculation using `count_live_vectors()` function that traverses versioned data structures to determine actual live vectors at any given version

- Introduce version-based vector count caching via `TreeMap<VersionNumber, usize>` in Collection struct for O(1) lookups of frequently accessed versions

- Implement incremental count updates during vector uploads that build upon previous cached counts rather than recalculating from scratch

- Add proper serialization/deserialization of vector count cache to persist across application restarts

- Create optimized lookup strategy: try cache first (O(1)), fall back to incremental counting from nearest cached version, use brute-force only as last resort

- Add comprehensive version traversal utilities in collection_version_utils.rs for querying historical vector states

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR does not contain any unnecessary/auto generated code changes.
- [x] The PR is made from a branch that's **not** called "main" and is up-to-date with "main".
- [x] The PR is **assigned** to the appropriate reviewers 

@tinkn Could you please review this when you have a moment? Thank you!
