### PR TITLE
Fix potential segfault in unsafe data structures

### DIFF
--- a/src/models/serializer/quotients_map.rs
+++ b/src/models/serializer/quotients_map.rs
@@ -7,7 +7,7 @@ use crate::models::{
     buffered_io::{BufIoError, BufferManager},
     common::TSHashTable,
     tf_idf_index::UnsafeVersionedVec,
-    tree_map::{Quotient, QuotientVec, QuotientsMap, QuotientsMapVec, UnsafeVersionedItem},
+    tree_map::{Quotient, QuotientVec, QuotientsMap, QuotientsMapVec, VersionedItem},
     types::FileOffset,
 };
 
@@ -205,8 +205,7 @@ impl<T: SimpleSerialize> SimpleSerialize for QuotientsMap<T> {
                 }
                 let key = bufman.read_u64_with_cursor(cursor)?;
                 let value_offset = bufman.read_u32_with_cursor(cursor)?;
-                let value =
-                    UnsafeVersionedItem::<T>::deserialize(bufman, FileOffset(value_offset))?;
+                let value = VersionedItem::<T>::deserialize(bufman, FileOffset(value_offset))?;
                 let q = Quotient {
                     value,
                     sequence_idx: i as u64,

--- a/src/models/serializer/versioned_item.rs
+++ b/src/models/serializer/versioned_item.rs
@@ -11,8 +11,7 @@ use super::SimpleSerialize;
 
 impl<T: SimpleSerialize> SimpleSerialize for VersionedItem<T> {
     fn serialize(&self, bufman: &BufferManager, cursor: u64) -> Result<u32, BufIoError> {
-        let next = &*self.next.read().unwrap();
-        let next_offset = if let Some(next) = next {
+        let next_offset = if let Some(next) = &self.next {
             next.serialize(bufman, cursor)?
         } else {
             u32::MAX
@@ -70,7 +69,7 @@ impl<T: SimpleSerialize> SimpleSerialize for VersionedItem<T> {
             serialized_at: RwLock::new(Some(offset)),
             version,
             value,
-            next: RwLock::new(next),
+            next,
         })
     }
 }

--- a/src/models/serializer/versioned_item.rs
+++ b/src/models/serializer/versioned_item.rs
@@ -1,17 +1,17 @@
-use std::{cell::UnsafeCell, sync::RwLock};
+use std::sync::RwLock;
 
 use crate::models::{
     buffered_io::{BufIoError, BufferManager},
-    tree_map::UnsafeVersionedItem,
+    tree_map::VersionedItem,
     types::FileOffset,
     versioning::VersionNumber,
 };
 
 use super::SimpleSerialize;
 
-impl<T: SimpleSerialize> SimpleSerialize for UnsafeVersionedItem<T> {
+impl<T: SimpleSerialize> SimpleSerialize for VersionedItem<T> {
     fn serialize(&self, bufman: &BufferManager, cursor: u64) -> Result<u32, BufIoError> {
-        let next = unsafe { &*self.next.get() };
+        let next = &*self.next.read().unwrap();
         let next_offset = if let Some(next) = next {
             next.serialize(bufman, cursor)?
         } else {
@@ -70,7 +70,7 @@ impl<T: SimpleSerialize> SimpleSerialize for UnsafeVersionedItem<T> {
             serialized_at: RwLock::new(Some(offset)),
             version,
             value,
-            next: UnsafeCell::new(next),
+            next: RwLock::new(next),
         })
     }
 }


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->

## Explanation
This PR fixes potential segfaults in the `UnsafeVersionedItem` and `UnsafeVersionedVec` data structures, also renaming them to `VersionedItem` and `VersionedVec` respectively, indicating that these structures are safe.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR does not contain any unnecessary/auto generated code changes.
- [x] The PR is made from a branch that's **not** called "main" and is up-to-date with "main".
- [x] The PR is **assigned** to the appropriate reviewers 

@tinkn Could you please review this when you have a moment? Thank you!
