### PR TITLE
got rid of double boxing

### DIFF
--- a/src/models/lazy_item.rs
+++ b/src/models/lazy_item.rs
@@ -50,11 +50,16 @@ impl<T: Debug> Debug for ProbLazyItem<T> {
 
 #[allow(unused)]
 impl<T> ProbLazyItem<T> {
-    pub fn new(data: T, file_id: IndexFileId, offset: FileOffset) -> *mut Self {
-        Box::into_raw(Box::new(Self {
-            data: AtomicPtr::new(Box::into_raw(Box::new(data))),
+   pub fn new(data: T, file_id: IndexFileId, offset: FileOffset) -> *mut Self {
+        let mut boxed = Box::new(Self {
+            data: AtomicPtr::new(ptr::null_mut()),
             file_index: FileIndex { offset, file_id },
-        }))
+        });
+        
+        let data_ptr = Box::into_raw(Box::new(data));
+        boxed.data.store(data_ptr, Ordering::Release);
+        
+        Box::into_raw(boxed)
     }
 
     pub fn new_pending(file_index: FileIndex) -> *mut Self {


### PR DESCRIPTION
Not exactly a bug fix,I juste removed double boxing in `ProbLazyItem::new()` by storing the data directly via a single `Box` for the entire struct along with a pointer for the data. I'm open to all suggestions

Fixes #

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x ] The PR does not contain any unnecessary/auto generated code changes.
- [ x] The PR is made from a branch that's **not** called "main" and is up-to-date with "main".
- [ ] The PR is **assigned** to the appropriate reviewers 

@<reviewer‑github‑handle> Could you please review this when you have a moment? Thank you!
