### PR TITLE
feat(hnsw): versioned serialization for latest version links

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,12 +43,12 @@ twox-hash = "2.1.0"
 parking_lot = "0.12.3"
 crossbeam = "0.8.4"
 utoipa = {version = "5.3.1", features = ["actix_extras"] }
+tempfile = "3.10.1"
 
 [dev-dependencies]
 criterion = "0.5.1"
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"
-tempfile = "3.10.1"
 tokio = { version = "1.37.0", features = ["rt"] }
 
 [features]

--- a/config.toml
+++ b/config.toml
@@ -6,6 +6,7 @@ sparse_raw_values_reranking_factor = 5
 rerank_sparse_with_raw_values = false
 tree_map_serialized_parts = 8
 index_file_min_size = 1_000_000 # in bytes
+enable_context_history = true
 
 [server]
 host = "127.0.0.1"

--- a/src/config_loader.rs
+++ b/src/config_loader.rs
@@ -21,6 +21,7 @@ pub struct Config {
     pub sparse_raw_values_reranking_factor: usize,
     pub rerank_sparse_with_raw_values: bool,
     pub index_file_min_size: u32,
+    pub enable_context_history: bool,
     #[serde(default)]
     pub cache: CacheConfig,
 }

--- a/src/indexes/hnsw/mod.rs
+++ b/src/indexes/hnsw/mod.rs
@@ -316,8 +316,8 @@ impl IndexOps for HNSWIndex {
         self.is_configured.load(Ordering::Acquire)
     }
 
-    fn flush(&self, _: &Collection) -> Result<(), WaCustomError> {
-        self.cache.flush_all()?;
+    fn flush(&self, _: &Collection, version: VersionNumber) -> Result<(), WaCustomError> {
+        self.cache.flush_all(version)?;
         Ok(())
     }
 

--- a/src/indexes/inverted/mod.rs
+++ b/src/indexes/inverted/mod.rs
@@ -230,7 +230,7 @@ impl IndexOps for InvertedIndex {
         self.is_configured.load(Ordering::Acquire)
     }
 
-    fn flush(&self, _: &Collection) -> Result<(), WaCustomError> {
+    fn flush(&self, _: &Collection, _version: VersionNumber) -> Result<(), WaCustomError> {
         self.root.serialize()?;
         self.root.cache.flush_all()?;
         Ok(())

--- a/src/indexes/mod.rs
+++ b/src/indexes/mod.rs
@@ -128,7 +128,7 @@ pub trait IndexOps: Send + Sync {
     fn is_configured(&self) -> bool;
 
     // save everything to disk
-    fn flush(&self, collection: &Collection) -> Result<(), WaCustomError>;
+    fn flush(&self, collection: &Collection, version: VersionNumber) -> Result<(), WaCustomError>;
 
     fn pre_commit_transaction(
         &self,
@@ -137,7 +137,7 @@ pub trait IndexOps: Send + Sync {
         config: &Config,
     ) -> Result<(), WaCustomError> {
         self.force_index(collection, version, config)?;
-        self.flush(collection)
+        self.flush(collection, version)
     }
 
     fn get_key_for_name(name: &str) -> u64 {

--- a/src/indexes/tf_idf/mod.rs
+++ b/src/indexes/tf_idf/mod.rs
@@ -182,7 +182,11 @@ impl IndexOps for TFIDFIndex {
         self.is_configured.load(Ordering::Acquire)
     }
 
-    fn flush(&self, _collection: &Collection) -> Result<(), WaCustomError> {
+    fn flush(
+        &self,
+        _collection: &Collection,
+        _version: VersionNumber,
+    ) -> Result<(), WaCustomError> {
         self.root.serialize()?;
         self.root.cache.flush_all()?;
         Ok(())

--- a/src/models/buffered_io.rs
+++ b/src/models/buffered_io.rs
@@ -1,14 +1,16 @@
 use dashmap::DashMap;
+use rustc_hash::FxHashMap;
 use std::collections::HashMap;
-use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::hash::Hash;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
+use std::{fmt, fs};
 
 use super::lru_cache::LRUCache;
+use super::versioning::VersionNumber;
 
 #[derive(Debug)]
 pub enum BufIoError {
@@ -519,6 +521,47 @@ impl FilelessBufferManager {
         })
     }
 
+    pub fn from_versioned(
+        buffer_size: usize,
+        root_path: &Path,
+        mapping_fn: impl Fn(&Path) -> Option<(VersionNumber, u64)>,
+    ) -> Result<Self, BufIoError> {
+        let regions = DashMap::new();
+        let mut file_size = 0;
+        let mut region_versions_map = FxHashMap::<u64, VersionNumber>::default();
+
+        for entry in fs::read_dir(root_path)? {
+            let entry = entry?;
+            let path = entry.path();
+            let Some((version, region_id)) = mapping_fn(&path) else {
+                continue;
+            };
+            if let Some(existing_version) = region_versions_map.get(&region_id) {
+                if **existing_version > *version {
+                    continue;
+                }
+            }
+            region_versions_map.insert(region_id, version);
+            let offset = region_id * buffer_size as u64;
+            let mut file = OpenOptions::new().read(true).open(path)?;
+            let mut region = FilelessBufferRegion::new(offset, buffer_size);
+            let buffer = region.buffer.get_mut().map_err(|_| BufIoError::Locking)?;
+            let bytes_read = file.read(&mut buffer[..]).map_err(BufIoError::Io)?;
+            region.end.store(bytes_read, Ordering::SeqCst);
+            regions.insert(offset, Arc::new(region));
+            let end = offset + bytes_read as u64;
+            file_size = file_size.max(end);
+        }
+
+        Ok(Self {
+            regions,
+            cursors: RwLock::new(HashMap::new()),
+            next_cursor_id: AtomicU64::new(0),
+            file_size: RwLock::new(file_size),
+            buffer_size,
+        })
+    }
+
     pub fn open_cursor(&self) -> Result<u64, BufIoError> {
         let cursor_id = self.next_cursor_id.fetch_add(1, Ordering::SeqCst);
         let mut cursors = self.cursors.write().map_err(|_| BufIoError::Locking)?;
@@ -723,6 +766,26 @@ impl FilelessBufferManager {
         }
         file.flush()?;
         file.sync_all()?;
+        Ok(())
+    }
+
+    pub fn flush_versioned(&self, mapping_fn: impl Fn(u64) -> PathBuf) -> Result<(), BufIoError> {
+        for region in self.regions.iter() {
+            if region.should_flush() {
+                let path = mapping_fn(region.start / self.buffer_size as u64);
+                let mut file = OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(false)
+                    .open(path)?;
+                let buffer = region.buffer.read().map_err(|_| BufIoError::Locking)?;
+                let end = region.end.load(Ordering::SeqCst);
+                file.write_all(&buffer[..end]).map_err(BufIoError::Io)?;
+                region.dirty.store(false, Ordering::SeqCst);
+                file.flush()?;
+                file.sync_all()?;
+            }
+        }
         Ok(())
     }
 

--- a/src/models/prob_node.rs
+++ b/src/models/prob_node.rs
@@ -15,7 +15,7 @@ use crate::indexes::hnsw::offset_counter::{self, IndexFileId};
 use self::offset_counter::HNSWIndexFileOffsetCounter;
 
 use super::{
-    buffered_io::BufIoError,
+    buffered_io::{BufIoError, BufferManager},
     cache_loader::HNSWIndexCache,
     common::TSHashTable,
     lazy_item::{FileIndex, ProbLazyItem},
@@ -348,6 +348,7 @@ impl ProbNode {
     pub fn build_from_raw(
         raw: <Self as RawDeserialize>::Raw,
         cache: &HNSWIndexCache,
+        dummy_bufman: &BufferManager,
         pending_items: &mut FxHashMap<FileIndex, SharedNode>,
         latest_version_links: &mut FxHashMap<FileOffset, SharedLatestNode>,
         latest_version_links_cursor: u64,
@@ -367,7 +368,7 @@ impl ProbNode {
                 Entry::Occupied(entry) => *entry.get(),
                 Entry::Vacant(entry) => {
                     let file_index = SharedLatestNode::deserialize_raw(
-                        &cache.latest_version_links_bufman, // not used
+                        dummy_bufman, // not used
                         &cache.latest_version_links_bufman,
                         u64::MAX, // not used
                         latest_version_links_cursor,
@@ -397,7 +398,7 @@ impl ProbNode {
                 Entry::Occupied(entry) => *entry.get(),
                 Entry::Vacant(entry) => {
                     let file_index = SharedLatestNode::deserialize_raw(
-                        &cache.latest_version_links_bufman, // not used
+                        dummy_bufman, // not used
                         &cache.latest_version_links_bufman,
                         u64::MAX, // not used
                         latest_version_links_cursor,
@@ -432,7 +433,7 @@ impl ProbNode {
                             Entry::Occupied(entry) => *entry.get(),
                             Entry::Vacant(entry) => {
                                 let file_index = SharedLatestNode::deserialize_raw(
-                                    &cache.latest_version_links_bufman, // not used
+                                    dummy_bufman, // not used
                                     &cache.latest_version_links_bufman,
                                     u64::MAX, // not used
                                     latest_version_links_cursor,

--- a/src/models/serializer/hnsw/latest_node.rs
+++ b/src/models/serializer/hnsw/latest_node.rs
@@ -5,7 +5,7 @@ use rustc_hash::FxHashSet;
 use crate::{
     indexes::hnsw::offset_counter::IndexFileId,
     models::{
-        buffered_io::{BufIoError, BufferManager},
+        buffered_io::{BufIoError, BufferManager, FilelessBufferManager},
         cache_loader::HNSWIndexCache,
         lazy_item::FileIndex,
         prob_node::{LatestNode, SharedLatestNode, SharedNode},
@@ -19,7 +19,7 @@ impl HNSWIndexSerialize for SharedLatestNode {
     fn serialize(
         &self,
         bufman: &BufferManager,
-        latest_version_links_bufman: &BufferManager,
+        latest_version_links_bufman: &FilelessBufferManager,
         cursor: u64,
         latest_version_links_cursor: u64,
     ) -> Result<u32, BufIoError> {
@@ -45,7 +45,7 @@ impl HNSWIndexSerialize for SharedLatestNode {
 
     fn deserialize(
         bufman: &BufferManager,
-        latest_version_links_bufman: &BufferManager,
+        latest_version_links_bufman: &FilelessBufferManager,
         file_index: FileIndex,
         cache: &HNSWIndexCache,
         max_loads: u16,
@@ -77,7 +77,7 @@ impl RawDeserialize for SharedLatestNode {
 
     fn deserialize_raw(
         _bufman: &BufferManager,
-        latest_version_links_bufman: &BufferManager,
+        latest_version_links_bufman: &FilelessBufferManager,
         _cursor: u64,
         latest_version_links_cursor: u64,
         offset: FileOffset,

--- a/src/models/serializer/hnsw/lazy_item.rs
+++ b/src/models/serializer/hnsw/lazy_item.rs
@@ -1,7 +1,7 @@
 use rustc_hash::FxHashSet;
 
 use crate::models::{
-    buffered_io::{BufIoError, BufferManager},
+    buffered_io::{BufIoError, BufferManager, FilelessBufferManager},
     cache_loader::HNSWIndexCache,
     lazy_item::FileIndex,
     prob_node::SharedNode,
@@ -13,7 +13,7 @@ impl HNSWIndexSerialize for SharedNode {
     fn serialize(
         &self,
         bufman: &BufferManager,
-        latest_version_links_bufman: &BufferManager,
+        latest_version_links_bufman: &FilelessBufferManager,
         cursor: u64,
         latest_version_links_cursor: u64,
     ) -> Result<u32, BufIoError> {
@@ -35,7 +35,7 @@ impl HNSWIndexSerialize for SharedNode {
 
     fn deserialize(
         _bufman: &BufferManager,
-        _latest_version_links_bufman: &BufferManager,
+        _latest_version_links_bufman: &FilelessBufferManager,
         file_index: FileIndex,
         cache: &HNSWIndexCache,
         max_loads: u16,

--- a/src/models/serializer/hnsw/mod.rs
+++ b/src/models/serializer/hnsw/mod.rs
@@ -10,7 +10,7 @@ use rustc_hash::FxHashSet;
 use crate::{
     indexes::hnsw::offset_counter::IndexFileId,
     models::{
-        buffered_io::{BufIoError, BufferManager},
+        buffered_io::{BufIoError, BufferManager, FilelessBufferManager},
         cache_loader::HNSWIndexCache,
         lazy_item::FileIndex,
         types::FileOffset,
@@ -21,14 +21,14 @@ pub trait HNSWIndexSerialize: Sized {
     fn serialize(
         &self,
         bufman: &BufferManager,
-        latest_version_links_bufman: &BufferManager,
+        latest_version_links_bufman: &FilelessBufferManager,
         cursor: u64,
         latest_version_links_cursor: u64,
     ) -> Result<u32, BufIoError>;
 
     fn deserialize(
         bufman: &BufferManager,
-        latest_version_links_bufman: &BufferManager,
+        latest_version_links_bufman: &FilelessBufferManager,
         file_index: FileIndex,
         cache: &HNSWIndexCache,
         max_loads: u16,
@@ -41,7 +41,7 @@ pub trait RawDeserialize: Sized {
 
     fn deserialize_raw(
         bufman: &BufferManager,
-        latest_version_links_bufman: &BufferManager,
+        latest_version_links_bufman: &FilelessBufferManager,
         cursor: u64,
         latest_version_links_cursor: u64,
         offset: FileOffset,

--- a/src/models/serializer/hnsw/neighbors.rs
+++ b/src/models/serializer/hnsw/neighbors.rs
@@ -8,7 +8,7 @@ use rustc_hash::FxHashSet;
 use crate::{
     indexes::hnsw::offset_counter::IndexFileId,
     models::{
-        buffered_io::{BufIoError, BufferManager},
+        buffered_io::{BufIoError, BufferManager, FilelessBufferManager},
         cache_loader::HNSWIndexCache,
         lazy_item::FileIndex,
         prob_node::{Neighbors, SharedLatestNode},
@@ -30,7 +30,7 @@ impl HNSWIndexSerialize for Neighbors {
     fn serialize(
         &self,
         bufman: &BufferManager,
-        _latest_version_links_bufman: &BufferManager,
+        _latest_version_links_bufman: &FilelessBufferManager,
         cursor: u64,
         _latest_version_links_cursor: u64,
     ) -> Result<u32, BufIoError> {
@@ -62,7 +62,7 @@ impl HNSWIndexSerialize for Neighbors {
 
     fn deserialize(
         bufman: &BufferManager,
-        latest_version_links_bufman: &BufferManager,
+        latest_version_links_bufman: &FilelessBufferManager,
         file_index: FileIndex,
         cache: &HNSWIndexCache,
         max_loads: u16,
@@ -116,7 +116,7 @@ impl RawDeserialize for Neighbors {
 
     fn deserialize_raw(
         bufman: &BufferManager,
-        _latest_version_links_bufman: &BufferManager,
+        _latest_version_links_bufman: &FilelessBufferManager,
         cursor: u64,
         _latest_version_links_cursor: u64,
         FileOffset(offset): FileOffset,

--- a/src/models/serializer/hnsw/node.rs
+++ b/src/models/serializer/hnsw/node.rs
@@ -5,7 +5,7 @@ use rustc_hash::FxHashSet;
 use crate::{
     indexes::hnsw::offset_counter::IndexFileId,
     models::{
-        buffered_io::{BufIoError, BufferManager},
+        buffered_io::{BufIoError, BufferManager, FilelessBufferManager},
         cache_loader::HNSWIndexCache,
         lazy_item::FileIndex,
         prob_node::{Neighbors, ProbNode, SharedLatestNode},
@@ -34,7 +34,7 @@ impl HNSWIndexSerialize for ProbNode {
     fn serialize(
         &self,
         bufman: &BufferManager,
-        latest_version_links_bufman: &BufferManager,
+        latest_version_links_bufman: &FilelessBufferManager,
         cursor: u64,
         latest_version_links_cursor: u64,
     ) -> Result<u32, BufIoError> {
@@ -102,7 +102,7 @@ impl HNSWIndexSerialize for ProbNode {
 
     fn deserialize(
         bufman: &BufferManager,
-        latest_version_links_bufman: &BufferManager,
+        latest_version_links_bufman: &FilelessBufferManager,
         file_index: FileIndex,
         cache: &HNSWIndexCache,
         max_loads: u16,
@@ -204,7 +204,7 @@ impl RawDeserialize for ProbNode {
 
     fn deserialize_raw(
         bufman: &BufferManager,
-        latest_version_links_bufman: &BufferManager,
+        latest_version_links_bufman: &FilelessBufferManager,
         cursor: u64,
         latest_version_links_cursor: u64,
         FileOffset(offset): FileOffset,


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->

## Explanation
This PR adds versioned serialization logic for "latest version links", this versioned serialization is gated behind a config option `enable_context_history`, if this option is set `false`, the "latest version links" is serialized to/deserialized from a single file (`nodes.ptr`), and when its set to `true` the "latest version links" are serialized to/deserialized from multiple files, split by regions and versions, the file name format is `{region-id}-{version}.ptr`.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR does not contain any unnecessary/auto generated code changes.
- [x] The PR is made from a branch that's **not** called "main" and is up-to-date with "main".
- [x] The PR is **assigned** to the appropriate reviewers 

@tinkn Could you please review this when you have a moment? Thank you!
