### PR TITLE
fix(hnsw/node): take write lock when updating neighbors

### DIFF
--- a/src/models/prob_node.rs
+++ b/src/models/prob_node.rs
@@ -283,7 +283,7 @@ impl ProbNode {
     }
 
     pub fn remove_neighbor_by_id(&self, id: InternalId) -> bool {
-        let _lock = self.freeze();
+        let _lock = self.lowest_index.write();
         for neighbor in &self.neighbors {
             let res = neighbor.fetch_update(Ordering::Release, Ordering::Acquire, |nbr| {
                 if let Some((nbr_id, _, _)) = unsafe { nbr.as_ref() } {
@@ -313,7 +313,7 @@ impl ProbNode {
     }
 
     pub fn remove_neighbor_by_index_and_id(&self, index: u8, id: InternalId) {
-        let _lock = self.freeze();
+        let _lock = self.lowest_index.write();
         let _ = self.neighbors[index as usize].fetch_update(
             Ordering::Release,
             Ordering::Acquire,


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->

## Explanation
This PR fixes a segfault in the HNSW index, by fixing the locking of node's neighbors.

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR does not contain any unnecessary/auto generated code changes.
- [x] The PR is made from a branch that's **not** called "main" and is up-to-date with "main".
- [x] The PR is **assigned** to the appropriate reviewers 

@tinkn Could you please review this when you have a moment? Thank you!
