### PR TITLE
Fix the 'len' and 'is_empty' methods of AtomicArray

### DIFF
--- a/src/models/atomic_array.rs
+++ b/src/models/atomic_array.rs
@@ -55,12 +55,13 @@ impl<T, const N: usize> AtomicArray<T, N> {
     }
 
     pub fn len(&self) -> usize {
+        let mut n = 0;
         for i in 0..N {
-            if self.items[i].load(Ordering::SeqCst).is_null() {
-                return i;
+            if !self.items[i].load(Ordering::SeqCst).is_null() {
+                n += 1;
             }
         }
-        N
+        n
     }
 
     pub fn last(&self) -> Option<*mut T> {
@@ -85,7 +86,7 @@ impl<T, const N: usize> AtomicArray<T, N> {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.items[0].load(Ordering::SeqCst).is_null()
+        self.len() == 0
     }
 
     pub fn insert(&self, idx: usize, value: *mut T) {
@@ -134,5 +135,29 @@ impl<T, const N: usize> AtomicArray<T, N> {
             }
         }
         (return_value, res.is_ok())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AtomicArray;
+
+    #[test]
+    fn test_atomic_array_len() {
+        let arr: AtomicArray<u8, 8> = AtomicArray::new();
+        assert_eq!(0, arr.len());
+        assert!(arr.is_empty());
+
+        let mut x: u8 = 100;
+        let x_ptr: *mut u8 = &mut x;
+        arr.push(x_ptr);
+
+        assert_eq!(1, arr.len());
+
+        let mut y: u8 = 200;
+        let y_ptr: *mut u8 = &mut y;
+        arr.insert(4, y_ptr);
+
+        assert_eq!(2, arr.len());
     }
 }


### PR DESCRIPTION
These methods were implemented in the way that it immediately returned the index at which a null pointer was found. This is flawed because 'push' is not the only method using which items can be added to the array. There are other methods such as 'insert' and 'get_or_insert' that insert an item at a specific index. So for e.g. if instead of pushing an item into an empty array, if it's inserted at index 2, then the length would still be 0 because the first slot (0 index) contains a null pointer.

This commit fixes 'len' by iterating over the array and returning the no. of slots containing non null pointers. 'is_empty' is implemented in terms of 'len'. A basic test confirming the behavior is also added.

<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR does not contain any unnecessary/auto generated code changes.
- [x] The PR is made from a branch that's **not** called "main" and is up-to-date with "main".
- [ ] The PR is **assigned** to the appropriate reviewers 

@a-rustacean @tinkn Could you please review this when you have a moment? Thank you!
