### PR TITLE
Use TreeMap to store internal metadata instead of lmdb

### DIFF
--- a/src/api/vectordb/collections/repo.rs
+++ b/src/api/vectordb/collections/repo.rs
@@ -37,7 +37,6 @@ pub(crate) async fn create_collection(
     }
 
     let env = &ctx.ain_env.persist;
-    let collections_db = &ctx.ain_env.collections_map.lmdb_collections_db;
     let lmdb = MetaDb::from_env(env.clone(), &name)
         .map_err(|err| CollectionsError::WaCustomError(WaCustomError::from(err)))?;
     let (vcs, hash) = VersionControl::new(env.clone(), lmdb.db)
@@ -71,15 +70,11 @@ pub(crate) async fn create_collection(
     )
     .map_err(CollectionsError::WaCustomError)?;
 
-    // adding the created collection into the in-memory map
+    // Add the created collection to the collections map (also
+    // persists the collection metadata to disk)
     ctx.ain_env
         .collections_map
         .insert_collection(collection.clone())
-        .map_err(CollectionsError::WaCustomError)?;
-
-    // persisting collection after creation
-    collection
-        .persist(env, *collections_db)
         .map_err(CollectionsError::WaCustomError)?;
 
     collection
@@ -144,22 +139,10 @@ pub(crate) async fn delete_collection_by_name(
     ctx: Arc<AppContext>,
     name: &str,
 ) -> Result<Arc<Collection>, CollectionsError> {
-    let env = &ctx.ain_env.persist;
-    let collections_db = &ctx.ain_env.collections_map.lmdb_collections_db;
-
-    let collection = get_collection_by_name(ctx.clone(), name).await?;
-
-    // deleting collection from disk
-    collection
-        .delete(env, *collections_db)
-        .map_err(CollectionsError::WaCustomError)?;
-
-    // deleting collection from in-memory map
     let collection = ctx
         .ain_env
         .collections_map
         .remove_collection(name)
         .map_err(CollectionsError::WaCustomError)?;
-
     Ok(collection)
 }

--- a/src/grpc/collections/mod.rs
+++ b/src/grpc/collections/mod.rs
@@ -94,18 +94,12 @@ crate::cfg_grpc! {
             )
             .map_err(Status::from)?;
 
-            // Store collection
+            // Add the created collection to the collections map (also
+            // persists the collection metadata to disk)
             self.context
                 .ain_env
                 .collections_map
                 .insert_collection(collection.clone())
-                .map_err(Status::from)?;
-            // persisting collection after creation
-            collection
-                .persist(
-                    env,
-                    self.context.ain_env.collections_map.lmdb_collections_db,
-                )
                 .map_err(Status::from)?;
 
             collection

--- a/src/indexes/hnsw/mod.rs
+++ b/src/indexes/hnsw/mod.rs
@@ -1,7 +1,7 @@
 pub(crate) mod offset_counter;
 pub(crate) mod types;
 
-use super::{IndexOps, InternalSearchResult};
+use super::{IndexData, IndexOps, InternalSearchResult};
 use crate::{
     config_loader::Config,
     metadata::{
@@ -14,6 +14,7 @@ use crate::{
         common::{TSHashTable, WaCustomError},
         meta_persist::store_values_range,
         prob_node::SharedLatestNode,
+        serializer::{CborDeserialize, CborSerialize},
         types::{DistanceMetric, FileOffset, HNSWLevel, InternalId, MetaDb, QuantizationMetric},
         versioning::VersionNumber,
     },
@@ -55,6 +56,9 @@ pub struct HNSWIndexData {
     pub storage_type: StorageType,
     pub sample_threshold: usize,
 }
+
+impl CborSerialize for HNSWIndexData {}
+impl CborDeserialize for HNSWIndexData {}
 
 pub struct HNSWIndex {
     pub root_vec: SharedLatestNode,
@@ -163,7 +167,6 @@ impl IndexOps for HNSWIndex {
     type IndexingInput = DenseInputEmbedding;
     type SearchInput = DenseSearchInput;
     type SearchOptions = DenseSearchOptions;
-    type Data = HNSWIndexData;
 
     fn validate_embedding(&self, embedding: Self::IndexingInput) -> Result<(), WaCustomError> {
         // @TODO(vineet): Add validation for metadata fields (if
@@ -371,10 +374,10 @@ impl IndexOps for HNSWIndex {
         Ok(())
     }
 
-    fn get_data(&self) -> Self::Data {
+    fn get_data(&self) -> Option<IndexData> {
         let offset = self.root_vec_ptr_offset();
         let offset_pseudo = self.pseudo_root_vec_ptr_offset();
-        Self::Data {
+        let data = HNSWIndexData {
             hnsw_params: self.hnsw_params.read().unwrap().clone(),
             levels_prob: self.levels_prob.clone(),
             dim: self.dim,
@@ -384,7 +387,8 @@ impl IndexOps for HNSWIndex {
             distance_metric: *self.distance_metric.read().unwrap(),
             storage_type: *self.storage_type.read().unwrap(),
             sample_threshold: self.sample_threshold,
-        }
+        };
+        Some(IndexData::Hnsw(data))
     }
 
     fn search_internal(

--- a/src/indexes/inverted/mod.rs
+++ b/src/indexes/inverted/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod types;
-use super::{IndexOps, InternalSearchResult};
+use super::{IndexData, IndexOps, InternalSearchResult};
 use crate::{
     config_loader::Config,
     models::{
@@ -112,7 +112,6 @@ impl IndexOps for InvertedIndex {
     type IndexingInput = SparseInputEmbedding;
     type SearchInput = SparseSearchInput;
     type SearchOptions = SparseSearchOptions;
-    type Data = InvertedIndexData;
 
     fn validate_embedding(&self, _embedding: Self::IndexingInput) -> Result<(), WaCustomError> {
         Ok(())
@@ -268,11 +267,12 @@ impl IndexOps for InvertedIndex {
         Ok(())
     }
 
-    fn get_data(&self) -> Self::Data {
-        Self::Data {
+    fn get_data(&self) -> Option<IndexData> {
+        let data = InvertedIndexData {
             quantization_bits: self.root.root.quantization_bits,
             sample_threshold: self.sample_threshold,
-        }
+        };
+        Some(IndexData::Inverted(data))
     }
 
     fn search_internal(

--- a/src/indexes/key_value.rs
+++ b/src/indexes/key_value.rs
@@ -12,7 +12,7 @@ use crate::{
     },
 };
 
-use super::IndexOps;
+use super::{IndexData, IndexOps};
 
 pub struct KeyValueInputPair {
     pub id: InternalId,
@@ -55,7 +55,6 @@ impl IndexOps for KeyValueIndex {
     type IndexingInput = KeyValueInputPair;
     type SearchInput = ();
     type SearchOptions = ();
-    type Data = ();
 
     fn validate_embedding(&self, _embedding: Self::IndexingInput) -> Result<(), WaCustomError> {
         Ok(())
@@ -122,7 +121,9 @@ impl IndexOps for KeyValueIndex {
         Ok(())
     }
 
-    fn get_data(&self) -> Self::Data {}
+    fn get_data(&self) -> Option<IndexData> {
+        None
+    }
 
     fn search_internal(
         &self,
@@ -135,14 +136,5 @@ impl IndexOps for KeyValueIndex {
         Err(WaCustomError::NotImplemented(
             "Regular index search cannot be used with key value index".to_string(),
         ))
-    }
-
-    fn persist(
-        &self,
-        _collection_name: &str,
-        _env: &lmdb::Environment,
-        _db: lmdb::Database,
-    ) -> Result<(), WaCustomError> {
-        Ok(())
     }
 }

--- a/src/indexes/mod.rs
+++ b/src/indexes/mod.rs
@@ -1,15 +1,22 @@
 use rayon::prelude::*;
 
-use std::{hash::Hasher, sync::RwLock};
+use std::{
+    fs::OpenOptions,
+    hash::{Hash, Hasher},
+    sync::{Arc, RwLock},
+};
 
-use lmdb::{Transaction, WriteFlags};
 use siphasher::sip::SipHasher24;
 
 use crate::{
     config_loader::Config,
     models::{
+        buffered_io::{BufIoError, BufferManager, BufferManagerFactory},
         collection::{Collection, RawVectorEmbedding},
         common::WaCustomError,
+        paths::get_data_path,
+        serializer::{CborDeserialize, CborSerialize},
+        tree_map::{TreeMap, TreeMapKey},
         types::{DocumentId, InternalId, MetaDb, VectorId},
         versioning::VersionNumber,
     },
@@ -20,6 +27,15 @@ pub(crate) mod inverted;
 pub(crate) mod key_value;
 pub(crate) mod tf_idf;
 pub(crate) mod usv;
+
+#[derive(PartialEq, Eq, Hash)]
+pub enum IndexType {
+    Hnsw,
+    Inverted,
+    TfIdf,
+    KeyValue,
+    Usv,
+}
 
 pub type InternalSearchResult = (
     InternalId,
@@ -35,7 +51,6 @@ pub trait IndexOps: Send + Sync {
     type IndexingInput: Send + Sync;
     type SearchInput: Send + Sync;
     type SearchOptions: Send + Sync;
-    type Data: serde::Serialize + serde::de::DeserializeOwned;
 
     fn validate_embedding(&self, embedding: Self::IndexingInput) -> Result<(), WaCustomError>;
 
@@ -156,54 +171,38 @@ pub trait IndexOps: Send + Sync {
         hasher.finish()
     }
 
-    fn get_data(&self) -> Self::Data;
+    fn get_data(&self) -> Option<IndexData>;
 
     fn persist(
         &self,
+        index_data_map: &IndexDataMap,
         collection_name: &str,
-        env: &lmdb::Environment,
-        db: lmdb::Database,
     ) -> Result<(), WaCustomError> {
-        let data = self.get_data();
-        let key = Self::get_key_for_name(collection_name).to_le_bytes();
-        let val = serde_cbor::to_vec(&data)
-            .map_err(|e| WaCustomError::SerializationError(e.to_string()))?;
-
-        let mut txn = env.begin_rw_txn()?;
-        txn.put(db, &key, &val, WriteFlags::empty())?;
-        txn.commit()?;
+        if let Some(data) = self.get_data() {
+            index_data_map
+                .insert(collection_name, data)
+                .map_err(|e| WaCustomError::BufIo(Arc::new(e)))?;
+        }
         Ok(())
     }
 
-    fn load_data(
-        env: &lmdb::Environment,
-        db: lmdb::Database,
-        collection_name: &str,
-    ) -> Result<Option<Self::Data>, WaCustomError> {
-        let txn = env.begin_ro_txn()?;
-        let key = Self::get_key_for_name(collection_name).to_le_bytes();
-        let data_bytes = match txn.get(db, &key) {
-            Ok(bytes) => Ok(bytes),
-            Err(lmdb::Error::NotFound) => return Ok(None),
-            Err(err) => Err(err),
-        }?;
-        let data = serde_cbor::from_slice(data_bytes)
-            .map_err(|e| WaCustomError::DeserializationError(e.to_string()))?;
+    // fn load_data<'a>(
+    //     index_data_map: &'a IndexDataMap,
+    //     collection_name: &str,
+    //     index_type: IndexType,
+    // ) -> Option<&'a IndexData> {
+    //     index_data_map.get(collection_name, index_type)
+    // }
 
-        Ok(data)
-    }
-
-    fn delete(
-        env: &lmdb::Environment,
-        db: lmdb::Database,
-        collection_name: &str,
-    ) -> Result<(), WaCustomError> {
-        let key = Self::get_key_for_name(collection_name).to_le_bytes();
-        let mut txn = env.begin_rw_txn()?;
-        txn.del(db, &key, None)?;
-        txn.commit()?;
-        Ok(())
-    }
+    // // @TODO: To be implemented in terms of TreeMap
+    // fn delete(
+    //     index_data_map: &'a IndexDataMap,
+    //     collection_name: &str,
+    //     index_type: IndexType,
+    // ) -> Result<(), WaCustomError> {
+    //     index_data_map.remove
+    //     Ok(())
+    // }
 
     fn search_internal(
         &self,
@@ -271,5 +270,111 @@ pub trait IndexOps: Send + Sync {
             .into_par_iter()
             .map(|query| self.search(collection, query, options, config, return_raw_text))
             .collect()
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum IndexData {
+    Hnsw(hnsw::HNSWIndexData),
+    Inverted(inverted::InvertedIndexData),
+    TfIdf(tf_idf::TFIDFIndexData),
+    Usv(usv::USVIndexData),
+}
+
+impl IndexData {
+    fn index_type(&self) -> IndexType {
+        match self {
+            Self::Hnsw(_) => IndexType::Hnsw,
+            Self::Inverted(_) => IndexType::Inverted,
+            Self::TfIdf(_) => IndexType::TfIdf,
+            Self::Usv(_) => IndexType::Usv,
+        }
+    }
+}
+
+impl CborSerialize for IndexData {}
+impl CborDeserialize for IndexData {}
+
+/// Index is identified by collection name (string) and type of index
+#[derive(PartialEq, Eq, Hash)]
+struct IndexId(String, IndexType);
+
+impl TreeMapKey for IndexId {
+    fn key(&self) -> u64 {
+        let mut hasher = SipHasher24::new();
+        self.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+/// Persistent storage for index data, implemented using TreeMap
+pub struct IndexDataMap {
+    inner: TreeMap<IndexId, IndexData>,
+}
+
+impl IndexDataMap {
+    /// Loads the IndexDataMap from disk (if it exists) or
+    /// creates a new one (if it's the first run).
+    ///
+    /// # Panics
+    /// The method panics if:
+    ///
+    ///   1. fails to open/read from files or
+    ///   2. fails to deserialize existing data
+    ///   3. fails to serialize empty TreeMap on first run
+    pub fn load_or_create() -> Self {
+        let data_path = get_data_path();
+        let file_path = data_path.join("indexes.dim");
+        let is_file_exists = std::fs::exists(&file_path).expect("Failed to check if file exists");
+
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(!is_file_exists)
+            .open(file_path)
+            .unwrap();
+
+        let dim_bufman = BufferManager::new(file, 8192).unwrap();
+        let data_bufmans = BufferManagerFactory::new(
+            data_path.into(),
+            |root, version: &VersionNumber| root.join(format!("indexes.{}.data", **version)),
+            8192,
+        );
+
+        // @NOTE: The TreeMap can be deserialized from disk only if
+        // it's initialized and serialized at least once, else it
+        // results in stack overflow. Hence, deserialize if the file
+        // exists, otherwise create a new TreeMap and immediately
+        // serialize it.
+        let inner = if is_file_exists {
+            TreeMap::deserialize(dim_bufman, data_bufmans)
+                .expect("Failed to deserialize TreeMap for CollectionMetadataMap")
+        } else {
+            let map = TreeMap::new(dim_bufman, data_bufmans);
+            // Immediately serialize it so that the file is created
+            map.serialize().expect("Failed to serialize TreeMap");
+            map
+        };
+        Self { inner }
+    }
+
+    pub fn get(&self, collection_name: &str, index_type: IndexType) -> Option<&IndexData> {
+        let index_id = IndexId(collection_name.to_owned(), index_type);
+        self.inner.get_latest(&index_id)
+    }
+
+    pub fn insert(&self, collection_name: &str, data: IndexData) -> Result<(), BufIoError> {
+        let index_type = data.index_type();
+        let index_id = IndexId(collection_name.to_owned(), index_type);
+        self.inner.insert(0.into(), &index_id, data);
+        self.inner.serialize()?;
+        Ok(())
+    }
+
+    pub fn remove(&self, collection_name: &str, index_type: IndexType) -> Result<(), BufIoError> {
+        let index_id = IndexId(collection_name.to_owned(), index_type);
+        self.inner.delete(0.into(), &index_id);
+        self.inner.serialize()?;
+        Ok(())
     }
 }

--- a/src/indexes/tf_idf/mod.rs
+++ b/src/indexes/tf_idf/mod.rs
@@ -1,4 +1,4 @@
-use super::{IndexOps, InternalSearchResult};
+use super::{IndexData, IndexOps, InternalSearchResult};
 use crate::{
     config_loader::Config,
     models::{
@@ -141,7 +141,6 @@ impl IndexOps for TFIDFIndex {
     type IndexingInput = TFIDFInputEmbedding;
     type SearchInput = TFIDFSearchInput;
     type SearchOptions = TFIDFSearchOptions;
-    type Data = TFIDFIndexData;
 
     fn validate_embedding(&self, _embedding: Self::IndexingInput) -> Result<(), WaCustomError> {
         Ok(())
@@ -232,12 +231,13 @@ impl IndexOps for TFIDFIndex {
         Ok(())
     }
 
-    fn get_data(&self) -> Self::Data {
-        Self::Data {
+    fn get_data(&self) -> Option<IndexData> {
+        let data = TFIDFIndexData {
             sample_threshold: self.sample_threshold,
             k1: self.k1,
             b: self.b,
-        }
+        };
+        Some(IndexData::TfIdf(data))
     }
 
     fn search_internal(

--- a/src/indexes/usv.rs
+++ b/src/indexes/usv.rs
@@ -1,5 +1,5 @@
 use super::inverted::types::{SamplingData, SparsePair};
-use super::{IndexOps, InternalSearchResult};
+use super::{IndexData, IndexOps, InternalSearchResult};
 use crate::models::meta_persist::store_usv_values_upper_bound;
 use crate::models::usv_index::USVIndexRoot;
 use crate::{
@@ -111,7 +111,6 @@ impl IndexOps for USVIndex {
     type IndexingInput = USVInputEmbedding;
     type SearchInput = USVSearchInput;
     type SearchOptions = USVSearchOptions;
-    type Data = USVIndexData;
 
     fn validate_embedding(&self, _embedding: Self::IndexingInput) -> Result<(), WaCustomError> {
         Ok(())
@@ -267,11 +266,12 @@ impl IndexOps for USVIndex {
         Ok(())
     }
 
-    fn get_data(&self) -> Self::Data {
-        Self::Data {
+    fn get_data(&self) -> Option<IndexData> {
+        let data = USVIndexData {
             quantization_bits: self.root.root.quantization_bits,
             sample_threshold: self.sample_threshold,
-        }
+        };
+        Some(IndexData::Usv(data))
     }
 
     fn search_internal(

--- a/src/models/atomic_array.rs
+++ b/src/models/atomic_array.rs
@@ -136,3 +136,69 @@ impl<T, const N: usize> AtomicArray<T, N> {
         (return_value, res.is_ok())
     }
 }
+
+pub struct AtomicArrayIter<'a, T, const N: usize> {
+    array: &'a AtomicArray<T, N>,
+    index: usize,
+}
+
+impl<T, const N: usize> Iterator for AtomicArrayIter<'_, T, N> {
+    type Item = *mut T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= N {
+            return None;
+        }
+
+        let ptr = self.array.items[self.index].load(Ordering::Acquire);
+        self.index += 1;
+        Some(ptr)
+    }
+}
+
+impl<'a, T, const N: usize> IntoIterator for &'a AtomicArray<T, N> {
+    type Item = *mut T;
+    type IntoIter = AtomicArrayIter<'a, T, N>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        AtomicArrayIter {
+            array: self,
+            index: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AtomicArray;
+
+    #[test]
+    fn test_atomic_array_iterator() {
+        let arr: AtomicArray<u8, 8> = AtomicArray::new();
+        assert_eq!(0, arr.len());
+        assert!(arr.is_empty());
+
+        let mut x: u8 = 100;
+        let x_ptr: *mut u8 = &mut x;
+        arr.push(x_ptr);
+
+        assert_eq!(1, arr.len());
+
+        let mut y: u8 = 200;
+        let y_ptr: *mut u8 = &mut y;
+        arr.insert(4, y_ptr);
+
+        let mut itr = arr.into_iter();
+        unsafe {
+            assert_eq!(100, *itr.next().unwrap()); // 0
+            assert!(itr.next().unwrap().is_null()); // 1
+            assert!(itr.next().unwrap().is_null()); // 2
+            assert!(itr.next().unwrap().is_null()); // 3
+            assert_eq!(200, *itr.next().unwrap()); // 4
+            assert!(itr.next().unwrap().is_null()); // 5
+            assert!(itr.next().unwrap().is_null()); // 6
+            assert!(itr.next().unwrap().is_null()); // 7
+            assert!(itr.next().is_none())
+        };
+    }
+}

--- a/src/models/collection.rs
+++ b/src/models/collection.rs
@@ -6,7 +6,7 @@ use super::common::WaCustomError;
 use super::indexing_manager::IndexingManager;
 use super::meta_persist::store_highest_internal_id;
 use super::paths::get_data_path;
-use super::serializer::SimpleSerialize;
+use super::serializer::{CborDeserialize, CborSerialize};
 use super::tree_map::{TreeMap, TreeMapVec};
 use super::types::{get_collections_path, DocumentId, InternalId, MetaDb, VectorId};
 use super::versioning::{VersionControl, VersionNumber, VersionSource};
@@ -95,30 +95,8 @@ pub struct CollectionMetadata {
     pub store_raw_text: bool,
 }
 
-impl SimpleSerialize for CollectionMetadata {
-    fn serialize(&self, bufman: &BufferManager, cursor: u64) -> Result<u32, BufIoError> {
-        let value = to_vec(&self).expect("Failed to serialize CollectionMetadata to cbor");
-        let num_bytes = value.len();
-        let mut buf = Vec::with_capacity(4 + num_bytes);
-        buf.extend_from_slice(&(num_bytes as u32).to_le_bytes());
-        buf.extend_from_slice(&value);
-        Ok(bufman.write_to_end_of_file(cursor, &buf)? as u32)
-    }
-
-    fn deserialize(
-        bufman: &BufferManager,
-        offset: super::types::FileOffset,
-    ) -> Result<Self, BufIoError> {
-        let cursor = bufman.open_cursor()?;
-        bufman.seek_with_cursor(cursor, offset.0 as u64)?;
-        let num_bytes = bufman.read_u32_with_cursor(cursor)?;
-        let mut buf = vec![0u8; num_bytes as usize];
-        bufman.read_with_cursor(cursor, &mut buf)?;
-        let coll_meta = serde_cbor::from_slice(&buf)
-            .expect("Failed to deserialize CollectionMetadata from cbor");
-        Ok(coll_meta)
-    }
-}
+impl CborSerialize for CollectionMetadata {}
+impl CborDeserialize for CollectionMetadata {}
 
 pub struct CollectionMetadataMap {
     inner: TreeMap<String, CollectionMetadata>,

--- a/src/models/collection.rs
+++ b/src/models/collection.rs
@@ -6,6 +6,7 @@ use super::common::WaCustomError;
 use super::indexing_manager::IndexingManager;
 use super::meta_persist::store_highest_internal_id;
 use super::paths::get_data_path;
+use super::serializer::SimpleSerialize;
 use super::tree_map::{TreeMap, TreeMapVec};
 use super::types::{get_collections_path, DocumentId, InternalId, MetaDb, VectorId};
 use super::versioning::{VersionControl, VersionNumber, VersionSource};
@@ -21,7 +22,6 @@ use crate::indexes::usv::{USVIndex, USVInputEmbedding};
 use crate::indexes::IndexOps;
 use crate::metadata::{MetadataFields, MetadataSchema};
 use chrono::{DateTime, TimeZone, Utc};
-use lmdb::{Database, Environment, Transaction, WriteFlags};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use serde_cbor::to_vec;
@@ -93,6 +93,99 @@ pub struct CollectionMetadata {
     pub metadata_schema: Option<MetadataSchema>,
     pub config: CollectionConfig,
     pub store_raw_text: bool,
+}
+
+impl SimpleSerialize for CollectionMetadata {
+    fn serialize(&self, bufman: &BufferManager, cursor: u64) -> Result<u32, BufIoError> {
+        let value = to_vec(&self).expect("Failed to serialize CollectionMetadata to cbor");
+        let num_bytes = value.len();
+        let mut buf = Vec::with_capacity(4 + num_bytes);
+        buf.extend_from_slice(&(num_bytes as u32).to_le_bytes());
+        buf.extend_from_slice(&value);
+        Ok(bufman.write_to_end_of_file(cursor, &buf)? as u32)
+    }
+
+    fn deserialize(
+        bufman: &BufferManager,
+        offset: super::types::FileOffset,
+    ) -> Result<Self, BufIoError> {
+        let cursor = bufman.open_cursor()?;
+        bufman.seek_with_cursor(cursor, offset.0 as u64)?;
+        let num_bytes = bufman.read_u32_with_cursor(cursor)?;
+        let mut buf = vec![0u8; num_bytes as usize];
+        bufman.read_with_cursor(cursor, &mut buf)?;
+        let coll_meta = serde_cbor::from_slice(&buf)
+            .expect("Failed to deserialize CollectionMetadata from cbor");
+        Ok(coll_meta)
+    }
+}
+
+pub struct CollectionMetadataMap {
+    inner: TreeMap<String, CollectionMetadata>,
+}
+
+impl CollectionMetadataMap {
+    /// Loads the CollectionMetadataMap from disk (if it exists) or
+    /// creates a new one (if it's the first run).
+    ///
+    /// # Panics
+    /// The method panics if:
+    ///
+    ///   1. fails to open/read from files or
+    ///   2. fails to deserialize existing data
+    ///   3. fails to serialize empty TreeMap on first run
+    pub fn load_or_create() -> Self {
+        let data_path = get_data_path();
+        let file_path = data_path.join("collections.dim");
+        let is_file_exists = std::fs::exists(&file_path).expect("Failed to check if file exists");
+
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(!is_file_exists)
+            .open(file_path)
+            .unwrap();
+
+        let dim_bufman = BufferManager::new(file, 8192).unwrap();
+        let data_bufmans = BufferManagerFactory::new(
+            data_path.into(),
+            |root, version: &VersionNumber| root.join(format!("collections.{}.data", **version)),
+            8192,
+        );
+
+        // @NOTE: The TreeMap can be deserialized from disk only if
+        // it's initialized and serialized at least once, else it
+        // results in stack overflow. Hence, deserialize if the file
+        // exists, otherwise create a new TreeMap and immediately
+        // serialize it.
+        let inner = if is_file_exists {
+            TreeMap::deserialize(dim_bufman, data_bufmans)
+                .expect("Failed to deserialize TreeMap for CollectionMetadataMap")
+        } else {
+            let map = TreeMap::new(dim_bufman, data_bufmans);
+            // Immediately serialize it so that the file is created
+            map.serialize().expect("Failed to serialize TreeMap");
+            map
+        };
+        Self { inner }
+    }
+
+    pub fn values(&self) -> Vec<CollectionMetadata> {
+        self.inner.latest_values().cloned().collect()
+    }
+
+    pub fn insert(&self, metadata: CollectionMetadata) -> Result<(), BufIoError> {
+        let coll_name = metadata.name.clone();
+        self.inner.insert(0.into(), &coll_name, metadata);
+        self.inner.serialize()?;
+        Ok(())
+    }
+
+    pub fn remove(&self, coll_name: &str) -> Result<(), BufIoError> {
+        self.inner.delete(0.into(), &coll_name.to_owned());
+        self.inner.serialize()?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -336,40 +429,6 @@ impl Collection {
     /// serializes the collection
     pub fn serialize(&self) -> Result<Vec<u8>, WaCustomError> {
         to_vec(&self.meta).map_err(|e| WaCustomError::SerializationError(e.to_string()))
-    }
-
-    /// persists the collection instance on disk (lmdb -> collections database)
-    pub fn persist(&self, env: &Environment, db: Database) -> Result<(), WaCustomError> {
-        let key = self.get_key();
-        let value = self.serialize()?;
-
-        let mut txn = env
-            .begin_rw_txn()
-            .map_err(|e| WaCustomError::DatabaseError(e.to_string()))?;
-
-        txn.put(db, &key, &value, WriteFlags::empty())
-            .map_err(|e| WaCustomError::DatabaseError(e.to_string()))?;
-        txn.commit()
-            .map_err(|e| WaCustomError::DatabaseError(e.to_string()))?;
-
-        Ok(())
-    }
-
-    /// deletes a collection instance from the disk (lmdb -> collections database)
-    #[allow(dead_code)]
-    pub fn delete(&self, env: &Environment, db: Database) -> Result<(), WaCustomError> {
-        let key = self.get_key();
-
-        let mut txn = env
-            .begin_rw_txn()
-            .map_err(|e| WaCustomError::DatabaseError(e.to_string()))?;
-
-        txn.del(db, &key, None)
-            .map_err(|e| WaCustomError::DatabaseError(e.to_string()))?;
-        txn.commit()
-            .map_err(|e| WaCustomError::DatabaseError(e.to_string()))?;
-
-        Ok(())
     }
 
     pub fn get_hnsw_index(&self) -> Option<Arc<HNSWIndex>> {

--- a/src/models/crypto.rs
+++ b/src/models/crypto.rs
@@ -15,7 +15,7 @@ pub struct SingleSHA256Hash(pub [u8; 32]);
 
 // Double SHA256 hash
 // Flow: Input -> |SHA256| -> Hash1 -> |SHA256| -> Final 32-byte hash
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct DoubleSHA256Hash(pub [u8; 32]);
 
 // Master key derived from user password and admin key

--- a/src/models/meta_persist.rs
+++ b/src/models/meta_persist.rs
@@ -2,7 +2,7 @@ use crate::macros::key;
 use crate::models::common::*;
 use crate::models::types::*;
 use crate::models::versioning::*;
-use lmdb::{Database, DatabaseFlags, Environment, Transaction, WriteFlags};
+use lmdb::{Transaction, WriteFlags};
 
 /// updates the current version of a collection
 pub fn update_current_version(
@@ -292,8 +292,4 @@ pub fn retrieve_highest_internal_id(lmdb: &MetaDb) -> Result<Option<u32>, WaCust
     let id = u32::from_le_bytes(bytes);
 
     Ok(Some(id))
-}
-
-pub fn lmdb_init_db(env: &Environment, name: &str) -> lmdb::Result<Database> {
-    env.create_db(Some(name), DatabaseFlags::empty())
 }

--- a/src/models/meta_persist.rs
+++ b/src/models/meta_persist.rs
@@ -2,10 +2,7 @@ use crate::macros::key;
 use crate::models::common::*;
 use crate::models::types::*;
 use crate::models::versioning::*;
-use lmdb::{Cursor, Database, DatabaseFlags, Environment, Transaction, WriteFlags};
-use serde_cbor::from_slice;
-
-use super::collection::CollectionMetadata;
+use lmdb::{Database, DatabaseFlags, Environment, Transaction, WriteFlags};
 
 /// updates the current version of a collection
 pub fn update_current_version(
@@ -297,25 +294,6 @@ pub fn retrieve_highest_internal_id(lmdb: &MetaDb) -> Result<Option<u32>, WaCust
     Ok(Some(id))
 }
 
-// TODO use lmdb_init_db function inside this function
-pub fn lmdb_init_collections_db(env: &Environment) -> lmdb::Result<Database> {
-    env.create_db(Some("collections"), DatabaseFlags::empty())
-}
-
 pub fn lmdb_init_db(env: &Environment, name: &str) -> lmdb::Result<Database> {
     env.create_db(Some(name), DatabaseFlags::empty())
-}
-
-pub(crate) fn load_collections(
-    env: &Environment,
-    db: Database,
-) -> lmdb::Result<Vec<CollectionMetadata>> {
-    let mut collections = Vec::new();
-    let txn = env.begin_ro_txn().unwrap();
-    let mut cursor = txn.open_ro_cursor(db).unwrap();
-    for (_k, v) in cursor.iter() {
-        let col: CollectionMetadata = from_slice(v).unwrap();
-        collections.push(col);
-    }
-    Ok(collections)
 }

--- a/src/models/serializer/mod.rs
+++ b/src/models/serializer/mod.rs
@@ -225,3 +225,36 @@ impl SimpleSerialize for Vec<u8> {
         Ok(buf)
     }
 }
+
+/// Marker traits for CBOR serialization
+///
+/// Any structs marked with these traits will automatically implement
+/// SimpleSerialize using `serde_cbor`.
+pub trait CborSerialize: serde::Serialize {}
+pub trait CborDeserialize: for<'de> serde::Deserialize<'de> {}
+
+// Blanket implementation of SimpleSerialize for types that opt-in via marker traits
+impl<T> SimpleSerialize for T
+where
+    T: CborSerialize + CborDeserialize,
+{
+    fn serialize(&self, bufman: &BufferManager, cursor: u64) -> Result<u32, BufIoError> {
+        let value = serde_cbor::to_vec(&self).expect("Failed to serialize to cbor");
+        let num_bytes = value.len();
+        let mut buf = Vec::with_capacity(4 + num_bytes);
+        buf.extend_from_slice(&(num_bytes as u32).to_le_bytes());
+        buf.extend_from_slice(&value);
+        Ok(bufman.write_to_end_of_file(cursor, &buf)? as u32)
+    }
+
+    fn deserialize(bufman: &BufferManager, offset: FileOffset) -> Result<Self, BufIoError> {
+        let cursor = bufman.open_cursor()?;
+        bufman.seek_with_cursor(cursor, offset.0 as u64)?;
+        let num_bytes = bufman.read_u32_with_cursor(cursor)?;
+        let mut buf = vec![0u8; num_bytes as usize];
+        bufman.read_with_cursor(cursor, &mut buf)?;
+        let coll_meta = serde_cbor::from_slice(&buf)
+            .expect("Failed to deserialize from cbor");
+        Ok(coll_meta)
+    }
+}

--- a/src/models/serializer/mod.rs
+++ b/src/models/serializer/mod.rs
@@ -253,8 +253,7 @@ where
         let num_bytes = bufman.read_u32_with_cursor(cursor)?;
         let mut buf = vec![0u8; num_bytes as usize];
         bufman.read_with_cursor(cursor, &mut buf)?;
-        let coll_meta = serde_cbor::from_slice(&buf)
-            .expect("Failed to deserialize from cbor");
+        let coll_meta = serde_cbor::from_slice(&buf).expect("Failed to deserialize from cbor");
         Ok(coll_meta)
     }
 }

--- a/src/models/tree_map.rs
+++ b/src/models/tree_map.rs
@@ -1,11 +1,12 @@
 use std::{
-    collections::VecDeque, marker::PhantomData, sync::{
+    collections::VecDeque, hash::{Hash, Hasher}, marker::PhantomData, sync::{
         atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
         Arc,
     },
 };
 
 use parking_lot::{RwLock, RwLockReadGuard};
+use siphasher::sip::SipHasher24;
 
 use super::{
     atomic_array::AtomicArray,
@@ -749,6 +750,14 @@ where
 impl TreeMapKey for u64 {
     fn key(&self) -> u64 {
         *self
+    }
+}
+
+impl TreeMapKey for String {
+    fn key(&self) -> u64 {
+        let mut hasher = SipHasher24::new();
+        self.hash(&mut hasher);
+        hasher.finish()
     }
 }
 

--- a/src/models/tree_map.rs
+++ b/src/models/tree_map.rs
@@ -1,5 +1,8 @@
 use std::{
-    collections::VecDeque, hash::{Hash, Hasher}, marker::PhantomData, sync::{
+    collections::VecDeque,
+    hash::{Hash, Hasher},
+    marker::PhantomData,
+    sync::{
         atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
         Arc,
     },

--- a/src/models/tree_map.rs
+++ b/src/models/tree_map.rs
@@ -1,6 +1,5 @@
 use std::{
-    marker::PhantomData,
-    sync::{
+    collections::VecDeque, marker::PhantomData, sync::{
         atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
         Arc,
     },
@@ -29,6 +28,8 @@ impl TreeMapKey for u32 {
     }
 }
 
+// TreeMap is a BufferManager-backed key-value store for internal use
+// in cosdata.
 pub struct TreeMap<K, V> {
     pub(crate) root: TreeMapNode<V>,
     pub(crate) dim_bufman: BufferManager,
@@ -429,6 +430,21 @@ impl<T> QuotientsMap<T> {
             unsafe { std::mem::transmute(q.value.read()) }
         })
     }
+
+    fn latest_values(&self) -> Vec<&T> {
+        self.map
+            .to_list()
+            .into_iter()
+            .map(|(_, v)| {
+                // SAFETY: here we are changing the lifetime of the value by using
+                // `std::mem::transmute`, which by definition is not safe, but given our use of
+                // this value and how we destroy it, its actually safe in this context.
+                unsafe { std::mem::transmute::<Option<&T>, Option<&T>>(v.value.read().latest()) }
+            })
+            .take_while(|v| v.is_some())
+            .map(|v| v.unwrap())
+            .collect()
+    }
 }
 
 impl<T: VersionedVecItem> QuotientsMapVec<T> {
@@ -506,6 +522,11 @@ where
 }
 
 impl<K: TreeMapKey, V> TreeMap<K, V> {
+    /// Constructor to create a new TreeMap
+    ///
+    /// @NOTE: In order to load an existing TreeMap that's already
+    /// been serialized to disk, use `TreeMap::deserialize` method
+    /// from the `SimpleSerialize` trait implementation.
     pub fn new(
         dim_bufman: BufferManager,
         data_bufmans: BufferManagerFactory<VersionNumber>,
@@ -549,6 +570,17 @@ impl<K: TreeMapKey, V> TreeMap<K, V> {
         let node = self.root.find_or_create_node(&path);
         node.get_versioned(key)
     }
+
+    /// Returns an iterator over all values in the TreeMap
+    ///
+    /// @NOTE: There's no equivalent iterator for keys because the
+    /// TreeMap doesn't actually store keys in it's raw form (keys are
+    /// hashed and stored). One way to workaround this is to store the
+    /// key additionally in every value, so that iterating over the
+    /// values also obtains the keys.
+    pub fn latest_values(&self) -> TreeMapValuesIter<'_, V> {
+        TreeMapValuesIter::new(&self.root)
+    }
 }
 
 impl<K, V: SimpleSerialize> TreeMap<K, V> {
@@ -584,6 +616,52 @@ impl<K, V: SimpleSerialize> TreeMap<K, V> {
             data_bufmans,
             _marker: PhantomData,
         })
+    }
+}
+
+pub struct TreeMapValuesIter<'a, T> {
+    stack: VecDeque<&'a TreeMapNode<T>>,
+    curr_iter: Option<(u16, std::vec::IntoIter<&'a T>)>,
+}
+
+impl<'a, T> TreeMapValuesIter<'a, T> {
+    pub fn new(root_node: &'a TreeMapNode<T>) -> Self {
+        let mut stack = VecDeque::new();
+        stack.push_front(root_node);
+        Self {
+            stack,
+            curr_iter: None,
+        }
+    }
+}
+
+impl<'a, T: std::fmt::Debug> Iterator for TreeMapValuesIter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            // @NOTE: Keeping node idx in state helps with debugging
+            if let Some((_nidx, iter)) = &mut self.curr_iter {
+                if let Some(item) = iter.next() {
+                    return Some(item);
+                }
+            }
+
+            if let Some(node) = self.stack.pop_front() {
+                let node_values = node.quotients.latest_values().into_iter();
+                self.curr_iter = Some((node.node_idx, node_values));
+                for child_ptr in &node.children {
+                    if !child_ptr.is_null() {
+                        unsafe {
+                            let child = &*child_ptr;
+                            self.stack.push_front(child)
+                        }
+                    }
+                }
+            } else {
+                return None;
+            }
+        }
     }
 }
 
@@ -676,8 +754,9 @@ impl TreeMapKey for u64 {
 
 #[cfg(test)]
 mod tests {
-    use std::fs::OpenOptions;
+    use std::{collections::HashSet, fs::OpenOptions};
 
+    use rand::Rng;
     use tempfile::tempdir;
 
     use super::*;
@@ -713,5 +792,125 @@ mod tests {
                 next: Some(Box::new(VersionedItem::new(1.into(), 29)))
             })
         );
+    }
+
+    #[test]
+    fn test_latest_values() {
+        let tempdir = tempdir().unwrap();
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .create(true)
+            .open(tempdir.as_ref().join("tree_map-2.dim"))
+            .unwrap();
+        let dim_bufman = BufferManager::new(file, 8192).unwrap();
+        let data_bufmans = BufferManagerFactory::new(
+            tempdir.as_ref().into(),
+            |root, version: &VersionNumber| root.join(format!("tree_map-2.{}.data", **version)),
+            8192,
+        );
+        let map: TreeMap<u64, u64> = TreeMap::new(dim_bufman, data_bufmans);
+
+        let mut rng = rand::thread_rng();
+
+        // Test with u16::MAX random values between 1 and u64::MAX
+        let count = u16::MAX as usize;
+
+        let test_values: Vec<u64> = (0..count).map(|_| rng.gen_range(1..=u64::MAX)).collect();
+
+        for i in &test_values {
+            map.insert(0.into(), i, *i);
+        }
+
+        let result: HashSet<&u64> = map.latest_values().collect();
+
+        assert_eq!(count, result.len());
+
+        for i in test_values {
+            assert!(result.contains(&i));
+        }
+    }
+
+    #[test]
+    fn test_treemap_latest_values_same_version() {
+        let tempdir = tempdir().unwrap();
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .create(true)
+            .open(tempdir.as_ref().join("tree_map-3.dim"))
+            .unwrap();
+        let dim_bufman = BufferManager::new(file, 8192).unwrap();
+        let data_bufmans = BufferManagerFactory::new(
+            tempdir.as_ref().into(),
+            |root, version: &VersionNumber| root.join(format!("tree_map-3.{}.data", **version)),
+            8192,
+        );
+        let map: TreeMap<u64, u64> = TreeMap::new(dim_bufman, data_bufmans);
+
+        map.insert(0.into(), &1, 100);
+        map.insert(0.into(), &2, 200);
+
+        map.serialize().unwrap();
+
+        // overwrite without changing version
+        map.insert(0.into(), &2, 250);
+
+        map.serialize().unwrap();
+
+        let result: HashSet<u64> = map.latest_values().copied().collect();
+        assert!(result.contains(&100));
+        assert!(result.contains(&250));
+        assert!(!result.contains(&200));
+    }
+
+    #[test]
+    fn test_treemap_latest_values_from_disk() {
+        let tempdir = tempdir().unwrap();
+
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(tempdir.as_ref().join("tree_map-4.dim"))
+            .unwrap();
+        let dim_bufman = BufferManager::new(file, 8192).unwrap();
+        let data_bufmans = BufferManagerFactory::new(
+            tempdir.as_ref().into(),
+            |root, version: &VersionNumber| root.join(format!("tree_map-4.{}.data", **version)),
+            8192,
+        );
+        let map: TreeMap<u64, u64> = TreeMap::new(dim_bufman, data_bufmans);
+        map.insert(0.into(), &1, 100);
+        map.insert(0.into(), &20, 2000);
+        map.insert(0.into(), &300, 30000);
+        map.insert(0.into(), &4000, 400000);
+
+        map.serialize().unwrap();
+
+        drop(map);
+
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(false)
+            .open(tempdir.as_ref().join("tree_map-4.dim"))
+            .unwrap();
+        let dim_bufman = BufferManager::new(file, 8192).unwrap();
+        let data_bufmans = BufferManagerFactory::new(
+            tempdir.as_ref().into(),
+            |root, version: &VersionNumber| root.join(format!("tree_map-4.{}.data", **version)),
+            8192,
+        );
+        let map: TreeMap<u64, u64> = TreeMap::deserialize(dim_bufman, data_bufmans).unwrap();
+
+        let result: HashSet<u64> = map.latest_values().copied().collect();
+
+        assert!(result.contains(&100));
+        assert!(result.contains(&2000));
+        assert!(result.contains(&30000));
+        assert!(result.contains(&400000));
     }
 }

--- a/src/models/types.rs
+++ b/src/models/types.rs
@@ -1,22 +1,9 @@
 use super::{
-    buffered_io::{BufIoError, BufferManagerFactory},
-    cache_loader::HNSWIndexCache,
-    collection::{Collection, CollectionMetadata},
-    collection_transaction::ImplicitTransaction,
-    crypto::{DoubleSHA256Hash, SingleSHA256Hash},
-    indexing_manager::IndexingManager,
-    inverted_index::InvertedIndexRoot,
-    meta_persist::{
+    buffered_io::{BufIoError, BufferManagerFactory}, cache_loader::HNSWIndexCache, collection::{Collection, CollectionMetadata}, collection_transaction::ImplicitTransaction, crypto::{DoubleSHA256Hash, SingleSHA256Hash}, indexing_manager::IndexingManager, inverted_index::InvertedIndexRoot, meta_persist::{
         lmdb_init_collections_db, lmdb_init_db, load_collections, retrieve_average_document_length,
         retrieve_background_version, retrieve_current_version, retrieve_highest_internal_id,
         retrieve_usv_values_upper_bound, retrieve_values_upper_bound,
-    },
-    paths::get_data_path,
-    prob_node::ProbNode,
-    tf_idf_index::TFIDFIndexRoot,
-    tree_map::{TreeMap, TreeMapKey, TreeMapVec},
-    usv_index::USVIndexRoot,
-    versioning::{VersionControl, VersionNumber},
+    }, paths::get_data_path, prob_node::ProbNode, serializer::SimpleSerialize, tf_idf_index::TFIDFIndexRoot, tree_map::{TreeMap, TreeMapKey, TreeMapVec}, usv_index::USVIndexRoot, versioning::{VersionControl, VersionNumber}
 };
 use crate::{
     args::CosdataArgs,
@@ -56,7 +43,7 @@ use crate::{
 };
 use crossbeam::channel;
 use dashmap::DashMap;
-use lmdb::{Cursor, Database, DatabaseFlags, Environment, Transaction, WriteFlags};
+use lmdb::{Database, DatabaseFlags, Environment, Transaction, WriteFlags};
 use rayon::ThreadPool;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -1435,55 +1422,71 @@ impl CollectionsMap {
 }
 
 pub struct UsersMap {
-    env: Arc<Environment>,
-    users_db: Database,
-    // (username, user details)
-    map: DashMap<String, User>,
+    inner: TreeMap<String, User>
 }
 
 impl UsersMap {
-    pub fn new(env: Arc<Environment>) -> lmdb::Result<Self> {
-        let users_db = env.create_db(Some("users"), DatabaseFlags::empty())?;
-        let txn = env.begin_ro_txn()?;
-        let mut cursor = txn.open_ro_cursor(users_db)?;
-        let map = DashMap::new();
+    /// Loads the UsersMap from disk (if it exists) or creates a new
+    /// one (if it's the first run).
+    ///
+    /// # Panics
+    /// The method panics if:
+    ///
+    ///   1. fails to open/read from files or
+    ///   2. fails to deserialize existing data
+    ///   3. fails to serialize empty TreeMap on first run
+    pub fn load_or_create() -> Self {
+        let data_path = get_data_path();
+        let file_path = data_path.join("users.dim");
+        let is_file_exists = std::fs::exists(&file_path).expect("Failed to check if file exists");
 
-        for (username, user_bytes) in cursor.iter() {
-            let username = String::from_utf8(username.to_vec()).unwrap();
-            let user = User::deserialize(user_bytes).unwrap();
-            map.insert(username, user);
-        }
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(!is_file_exists)
+            .open(file_path)
+            .unwrap();
 
-        drop(cursor);
-        txn.abort();
+        let dim_bufman = BufferManager::new(file, 8192).unwrap();
+        let data_bufmans = BufferManagerFactory::new(
+            data_path.into(),
+            |root, version: &VersionNumber| root.join(format!("users.{}.data", **version)),
+            8192,
+        );
 
-        Ok(Self { env, users_db, map })
+        // @NOTE: The TreeMap can be deserialized from disk only if
+        // it's initialized and serialized at least once, else it
+        // results in stack overflow. Hence, deserialize if the file
+        // exists, otherwise create a new TreeMap and immediately
+        // serialize it.
+        let inner = if is_file_exists {
+            TreeMap::deserialize(dim_bufman, data_bufmans)
+                .expect("Failed to deserialize TreeMap for UsersMap")
+        } else {
+            let map = TreeMap::new(dim_bufman, data_bufmans);
+            // Immediately serialize it so that the file is created
+            map.serialize().expect("Failed to serialize TreeMap");
+            map
+        };
+        Self { inner }
     }
 
-    pub fn add_user(&self, username: String, password_hash: DoubleSHA256Hash) -> lmdb::Result<()> {
+    pub fn add_user(
+        &self,
+        username: String,
+        password_hash: DoubleSHA256Hash,
+    ) -> Result<(), BufIoError> {
         let user = User {
             username: username.clone(),
             password_hash,
         };
-        let user_bytes = user.serialize();
-        let username_bytes = username.as_bytes();
-
-        let mut txn = self.env.begin_rw_txn()?;
-        txn.put(
-            self.users_db,
-            &username_bytes,
-            &user_bytes,
-            WriteFlags::empty(),
-        )?;
-        txn.commit()?;
-
-        self.map.insert(username, user);
-
+        self.inner.insert(0.into(), &username, user);
+        self.inner.serialize()?;
         Ok(())
     }
 
     pub fn get_user(&self, username: &str) -> Option<User> {
-        self.map.get(username).map(|user| user.value().clone())
+        self.inner.get_latest(&username.into()).cloned()
     }
 }
 
@@ -1493,26 +1496,33 @@ pub struct User {
     pub password_hash: DoubleSHA256Hash,
 }
 
-impl User {
-    fn serialize(&self) -> Vec<u8> {
+impl SimpleSerialize for User {
+    fn serialize(&self, bufman: &BufferManager, cursor: u64) -> Result<u32, BufIoError> {
         let username_bytes = self.username.as_bytes();
-        let mut buf = Vec::with_capacity(32 + username_bytes.len());
+        let mut buf = Vec::with_capacity(32 + 1 + username_bytes.len());
         buf.extend_from_slice(&self.password_hash.0);
+        buf.push(username_bytes.len() as u8);
         buf.extend_from_slice(username_bytes);
-        buf
+        Ok(bufman.write_to_end_of_file(cursor, &buf)? as u32)
     }
 
-    fn deserialize(buf: &[u8]) -> Result<Self, String> {
-        if buf.len() < 32 {
-            return Err("Input must be at least 32 bytes".to_string());
-        }
-        let mut password_hash = [0u8; 32];
-        password_hash.copy_from_slice(&buf[..32]);
-        let username_bytes = buf[32..].to_vec();
-        let username = String::from_utf8(username_bytes).map_err(|err| err.to_string())?;
-        Ok(Self {
+    fn deserialize(bufman: &BufferManager, offset: FileOffset) -> Result<Self, BufIoError> {
+        let cursor = bufman.open_cursor()?;
+        bufman.seek_with_cursor(cursor, offset.0 as u64)?;
+
+        let mut password_hash_buf = [0u8; 32];
+        bufman.read_with_cursor(cursor, &mut password_hash_buf)?;
+        let password_hash = DoubleSHA256Hash(password_hash_buf);
+
+        let username_size = bufman.read_u8_with_cursor(cursor)?;
+        let mut username_buf = vec![0u8; username_size as usize];
+        bufman.read_with_cursor(cursor, &mut username_buf)?;
+        let username = std::str::from_utf8(&username_buf)
+            .expect("Invalid utf-8")
+            .to_string();
+        Ok(User {
             username,
-            password_hash: DoubleSHA256Hash(password_hash),
+            password_hash,
         })
     }
 }
@@ -1668,13 +1678,7 @@ pub fn get_app_env(
     // Add more resilient error handling for collections_map loading
     let collections_map = CollectionsMap::load(env_arc.clone(), config, threadpool)?;
 
-    let users_map = match UsersMap::new(env_arc.clone()) {
-        Ok(map) => map,
-        Err(err) => {
-            println!("Warning: Failed to load users map: {}", err);
-            return Err(WaCustomError::DatabaseError(err.to_string()));
-        }
-    };
+    let users_map = UsersMap::load_or_create();
 
     // Use the admin key as the password instead of hardcoded "admin"
     let username = "admin".to_string();

--- a/src/models/types.rs
+++ b/src/models/types.rs
@@ -13,7 +13,7 @@ use super::{
     },
     paths::get_data_path,
     prob_node::ProbNode,
-    serializer::SimpleSerialize,
+    serializer::{CborDeserialize, CborSerialize},
     tf_idf_index::TFIDFIndexRoot,
     tree_map::{TreeMap, TreeMapKey, TreeMapVec},
     usv_index::USVIndexRoot,
@@ -1506,42 +1506,14 @@ impl UsersMap {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct User {
     pub username: String,
     pub password_hash: DoubleSHA256Hash,
 }
 
-impl SimpleSerialize for User {
-    fn serialize(&self, bufman: &BufferManager, cursor: u64) -> Result<u32, BufIoError> {
-        let username_bytes = self.username.as_bytes();
-        let mut buf = Vec::with_capacity(32 + 1 + username_bytes.len());
-        buf.extend_from_slice(&self.password_hash.0);
-        buf.push(username_bytes.len() as u8);
-        buf.extend_from_slice(username_bytes);
-        Ok(bufman.write_to_end_of_file(cursor, &buf)? as u32)
-    }
-
-    fn deserialize(bufman: &BufferManager, offset: FileOffset) -> Result<Self, BufIoError> {
-        let cursor = bufman.open_cursor()?;
-        bufman.seek_with_cursor(cursor, offset.0 as u64)?;
-
-        let mut password_hash_buf = [0u8; 32];
-        bufman.read_with_cursor(cursor, &mut password_hash_buf)?;
-        let password_hash = DoubleSHA256Hash(password_hash_buf);
-
-        let username_size = bufman.read_u8_with_cursor(cursor)?;
-        let mut username_buf = vec![0u8; username_size as usize];
-        bufman.read_with_cursor(cursor, &mut username_buf)?;
-        let username = std::str::from_utf8(&username_buf)
-            .expect("Invalid utf-8")
-            .to_string();
-        Ok(User {
-            username,
-            password_hash,
-        })
-    }
-}
+impl CborSerialize for User {}
+impl CborDeserialize for User {}
 
 pub struct SessionDetails {
     pub created_at: u64,

--- a/src/models/types.rs
+++ b/src/models/types.rs
@@ -1,9 +1,23 @@
 use super::{
-    buffered_io::{BufIoError, BufferManagerFactory}, cache_loader::HNSWIndexCache, collection::{Collection, CollectionMetadata}, collection_transaction::ImplicitTransaction, crypto::{DoubleSHA256Hash, SingleSHA256Hash}, indexing_manager::IndexingManager, inverted_index::InvertedIndexRoot, meta_persist::{
-        lmdb_init_collections_db, lmdb_init_db, load_collections, retrieve_average_document_length,
-        retrieve_background_version, retrieve_current_version, retrieve_highest_internal_id,
-        retrieve_usv_values_upper_bound, retrieve_values_upper_bound,
-    }, paths::get_data_path, prob_node::ProbNode, serializer::SimpleSerialize, tf_idf_index::TFIDFIndexRoot, tree_map::{TreeMap, TreeMapKey, TreeMapVec}, usv_index::USVIndexRoot, versioning::{VersionControl, VersionNumber}
+    buffered_io::{BufIoError, BufferManagerFactory},
+    cache_loader::HNSWIndexCache,
+    collection::{Collection, CollectionMetadata, CollectionMetadataMap},
+    collection_transaction::ImplicitTransaction,
+    crypto::{DoubleSHA256Hash, SingleSHA256Hash},
+    indexing_manager::IndexingManager,
+    inverted_index::InvertedIndexRoot,
+    meta_persist::{
+        lmdb_init_db, retrieve_average_document_length, retrieve_background_version,
+        retrieve_current_version, retrieve_highest_internal_id, retrieve_usv_values_upper_bound,
+        retrieve_values_upper_bound,
+    },
+    paths::get_data_path,
+    prob_node::ProbNode,
+    serializer::SimpleSerialize,
+    tf_idf_index::TFIDFIndexRoot,
+    tree_map::{TreeMap, TreeMapKey, TreeMapVec},
+    usv_index::USVIndexRoot,
+    versioning::{VersionControl, VersionNumber},
 };
 use crate::{
     args::CosdataArgs,
@@ -535,10 +549,8 @@ impl MetaDb {
 
 pub struct CollectionsMap {
     inner_collections: DashMap<String, Arc<Collection>>,
+    metadata_map: CollectionMetadataMap,
     lmdb_env: Arc<Environment>,
-    // made it public temporarily
-    // just to be able to persist collections from outside CollectionsMap
-    pub(crate) lmdb_collections_db: Database,
     lmdb_hnsw_index_db: Database,
     lmdb_inverted_index_db: Database,
     lmdb_tf_idf_index_db: Database,
@@ -547,15 +559,14 @@ pub struct CollectionsMap {
 
 impl CollectionsMap {
     fn new(env: Arc<Environment>) -> lmdb::Result<Self> {
-        let collections_db = lmdb_init_collections_db(&env)?;
         let hnsw_index_db = lmdb_init_db(&env, "hnsw_indexes")?;
         let inverted_index_db = lmdb_init_db(&env, "inverted_indexes")?;
         let tf_idf_index_db = lmdb_init_db(&env, "tf_idf_indexes")?;
         let usv_index_db = lmdb_init_db(&env, "usv_indexes")?;
         let res = Self {
             inner_collections: DashMap::new(),
+            metadata_map: CollectionMetadataMap::load_or_create(),
             lmdb_env: env,
-            lmdb_collections_db: collections_db,
             lmdb_hnsw_index_db: hnsw_index_db,
             lmdb_inverted_index_db: inverted_index_db,
             lmdb_tf_idf_index_db: tf_idf_index_db,
@@ -573,13 +584,7 @@ impl CollectionsMap {
         let collections_map =
             Self::new(env.clone()).map_err(|e| WaCustomError::DatabaseError(e.to_string()))?;
 
-        let collections = load_collections(
-            &collections_map.lmdb_env,
-            collections_map.lmdb_collections_db,
-        )
-        .map_err(|e| WaCustomError::DatabaseError(e.to_string()))?;
-
-        for collection_meta in collections {
+        for collection_meta in collections_map.metadata_map.values() {
             println!("Loading collection: {}", collection_meta.name);
             let lmdb = MetaDb::from_env(collections_map.lmdb_env.clone(), &collection_meta.name)?;
             let current_version = retrieve_current_version(&lmdb)?;
@@ -1321,11 +1326,16 @@ impl CollectionsMap {
         Ok(())
     }
 
-    /// inserts a collection into the collections map
-    #[allow(dead_code)]
+    /// inserts a collection into the collections map, as well as
+    /// stores the collection metadata (along with persisting it to
+    /// disk)
     pub fn insert_collection(&self, collection: Arc<Collection>) -> Result<(), WaCustomError> {
+        let metadata = collection.meta.clone();
         self.inner_collections
             .insert(collection.meta.name.to_owned(), collection);
+        self.metadata_map
+            .insert(metadata)
+            .map_err(|e| WaCustomError::BufIo(Arc::new(e)))?;
         Ok(())
     }
 
@@ -1391,15 +1401,21 @@ impl CollectionsMap {
         }
     }
 
-    /// removes a collection from the in-memory map
+    /// Removes a collection from the in-memory map, as well as
+    /// deletes the collection metadata persisted on the disk
     ///
     /// returns the removed collection in case of success
     ///
-    /// returns error if not found
-    #[allow(dead_code)]
+    /// returns error if not found or in case there's an error
+    /// removing the metadata from the TreeMap persisted to disk
     pub fn remove_collection(&self, name: &str) -> Result<Arc<Collection>, WaCustomError> {
         match self.inner_collections.remove(name) {
-            Some((_, collection)) => Ok(collection),
+            Some((_, collection)) => {
+                self.metadata_map
+                    .remove(name)
+                    .map_err(|e| WaCustomError::BufIo(Arc::new(e)))?;
+                Ok(collection)
+            }
             None => {
                 // collection not found, return an error response
                 Err(WaCustomError::NotFound("collection".into()))
@@ -1422,7 +1438,7 @@ impl CollectionsMap {
 }
 
 pub struct UsersMap {
-    inner: TreeMap<String, User>
+    inner: TreeMap<String, User>,
 }
 
 impl UsersMap {

--- a/src/models/types.rs
+++ b/src/models/types.rs
@@ -7,9 +7,8 @@ use super::{
     indexing_manager::IndexingManager,
     inverted_index::InvertedIndexRoot,
     meta_persist::{
-        lmdb_init_db, retrieve_average_document_length, retrieve_background_version,
-        retrieve_current_version, retrieve_highest_internal_id, retrieve_usv_values_upper_bound,
-        retrieve_values_upper_bound,
+        retrieve_average_document_length, retrieve_background_version, retrieve_current_version,
+        retrieve_highest_internal_id, retrieve_usv_values_upper_bound, retrieve_values_upper_bound,
     },
     paths::get_data_path,
     prob_node::ProbNode,
@@ -38,7 +37,7 @@ use crate::{
         key_value::KeyValueIndex,
         tf_idf::TFIDFIndex,
         usv::USVIndex,
-        IndexOps,
+        IndexData, IndexDataMap, IndexOps, IndexType,
     },
     metadata::{schema::MetadataDimensions, QueryFilterDimensions, HIGH_WEIGHT},
     models::{
@@ -550,27 +549,17 @@ impl MetaDb {
 pub struct CollectionsMap {
     inner_collections: DashMap<String, Arc<Collection>>,
     metadata_map: CollectionMetadataMap,
+    index_data_map: IndexDataMap,
     lmdb_env: Arc<Environment>,
-    lmdb_hnsw_index_db: Database,
-    lmdb_inverted_index_db: Database,
-    lmdb_tf_idf_index_db: Database,
-    lmdb_usv_index_db: Database,
 }
 
 impl CollectionsMap {
     fn new(env: Arc<Environment>) -> lmdb::Result<Self> {
-        let hnsw_index_db = lmdb_init_db(&env, "hnsw_indexes")?;
-        let inverted_index_db = lmdb_init_db(&env, "inverted_indexes")?;
-        let tf_idf_index_db = lmdb_init_db(&env, "tf_idf_indexes")?;
-        let usv_index_db = lmdb_init_db(&env, "usv_indexes")?;
         let res = Self {
             inner_collections: DashMap::new(),
             metadata_map: CollectionMetadataMap::load_or_create(),
+            index_data_map: IndexDataMap::load_or_create(),
             lmdb_env: env,
-            lmdb_hnsw_index_db: hnsw_index_db,
-            lmdb_inverted_index_db: inverted_index_db,
-            lmdb_tf_idf_index_db: tf_idf_index_db,
-            lmdb_usv_index_db: usv_index_db,
         };
         Ok(res)
     }
@@ -803,14 +792,22 @@ impl CollectionsMap {
             return Ok(None);
         }
 
-        let Some(hnsw_index_data) = HNSWIndex::load_data(
-            &self.lmdb_env,
-            self.lmdb_hnsw_index_db,
-            &collection_meta.name,
-        )?
-        else {
-            return Ok(None);
+        let data = self
+            .index_data_map
+            .get(&collection_meta.name, IndexType::Hnsw);
+        let hnsw_index_data = match data {
+            Some(index_data) => {
+                if let IndexData::Hnsw(d) = index_data {
+                    d
+                } else {
+                    // As index data is loaded at initialization, it's
+                    // better to panic
+                    panic!("Index data type mismatch");
+                }
+            }
+            None => return Ok(None),
         };
+
         let prop_file_path = index_path.join("prop.data");
         let prop_file_result = OpenOptions::new()
             .create(true)
@@ -1101,12 +1098,12 @@ impl CollectionsMap {
         let hnsw_index = HNSWIndex::new(
             root_ptr,
             pseudo_root_ptr,
-            hnsw_index_data.levels_prob,
+            hnsw_index_data.levels_prob.clone(),
             hnsw_index_data.dim,
-            hnsw_index_data.quantization_metric,
+            hnsw_index_data.quantization_metric.clone(),
             distance_metric,
             hnsw_index_data.storage_type,
-            hnsw_index_data.hnsw_params,
+            hnsw_index_data.hnsw_params.clone(),
             cache,
             values_range.unwrap_or((-1.0, 1.0)),
             hnsw_index_data.sample_threshold,
@@ -1131,13 +1128,20 @@ impl CollectionsMap {
             return Ok(None);
         }
 
-        let Some(inverted_index_data) = InvertedIndex::load_data(
-            &self.lmdb_env,
-            self.lmdb_inverted_index_db,
-            &collection_meta.name,
-        )?
-        else {
-            return Ok(None);
+        let data = self
+            .index_data_map
+            .get(&collection_meta.name, IndexType::Inverted);
+        let inverted_index_data = match data {
+            Some(index_data) => {
+                if let IndexData::Inverted(d) = index_data {
+                    d
+                } else {
+                    // As index data is loaded at initialization, it's
+                    // better to panic
+                    panic!("Index data type mismatch");
+                }
+            }
+            None => return Ok(None),
         };
 
         let values_upper_bound = retrieve_values_upper_bound(lmdb)?;
@@ -1170,13 +1174,20 @@ impl CollectionsMap {
             return Ok(None);
         }
 
-        let Some(inverted_index_data) = TFIDFIndex::load_data(
-            &self.lmdb_env,
-            self.lmdb_tf_idf_index_db,
-            &collection_meta.name,
-        )?
-        else {
-            return Ok(None);
+        let data = self
+            .index_data_map
+            .get(&collection_meta.name, IndexType::TfIdf);
+        let tfidf_index_data = match data {
+            Some(index_data) => {
+                if let IndexData::TfIdf(d) = index_data {
+                    d
+                } else {
+                    // As index data is loaded at initialization, it's
+                    // better to panic
+                    panic!("Index data type mismatch");
+                }
+            }
+            None => return Ok(None),
         };
 
         let average_document_length = retrieve_average_document_length(lmdb)?;
@@ -1187,9 +1198,9 @@ impl CollectionsMap {
             documents: RwLock::new(Vec::new()),
             documents_collected: AtomicUsize::new(0),
             sampling_data: crate::indexes::tf_idf::SamplingData::default(),
-            sample_threshold: inverted_index_data.sample_threshold,
-            k1: inverted_index_data.k1,
-            b: inverted_index_data.b,
+            sample_threshold: tfidf_index_data.sample_threshold,
+            k1: tfidf_index_data.k1,
+            b: tfidf_index_data.b,
         };
 
         Ok(Some(inverted_index))
@@ -1238,13 +1249,20 @@ impl CollectionsMap {
             return Ok(None);
         }
 
-        let Some(usv_index_data) = USVIndex::load_data(
-            &self.lmdb_env,
-            self.lmdb_usv_index_db,
-            &collection_meta.name,
-        )?
-        else {
-            return Ok(None);
+        let data = self
+            .index_data_map
+            .get(&collection_meta.name, IndexType::Usv);
+        let usv_index_data = match data {
+            Some(index_data) => {
+                if let IndexData::Usv(d) = index_data {
+                    d
+                } else {
+                    // As index data is loaded at initialization, it's
+                    // better to panic
+                    panic!("Index data type mismatch");
+                }
+            }
+            None => return Ok(None),
         };
 
         let values_upper_bound = retrieve_usv_values_upper_bound(lmdb)?;
@@ -1266,11 +1284,7 @@ impl CollectionsMap {
         collection: &Collection,
         hnsw_index: Arc<HNSWIndex>,
     ) -> Result<(), WaCustomError> {
-        hnsw_index.persist(
-            &collection.meta.name,
-            &self.lmdb_env,
-            self.lmdb_hnsw_index_db,
-        )?;
+        hnsw_index.persist(&self.index_data_map, &collection.meta.name)?;
         *collection.hnsw_index.write() = Some(hnsw_index);
         Ok(())
     }
@@ -1280,11 +1294,7 @@ impl CollectionsMap {
         collection: &Collection,
         inverted_index: Arc<InvertedIndex>,
     ) -> Result<(), WaCustomError> {
-        inverted_index.persist(
-            &collection.meta.name,
-            &self.lmdb_env,
-            self.lmdb_inverted_index_db,
-        )?;
+        inverted_index.persist(&self.index_data_map, &collection.meta.name)?;
         *collection.inverted_index.write() = Some(inverted_index);
         Ok(())
     }
@@ -1294,11 +1304,7 @@ impl CollectionsMap {
         collection: &Collection,
         tf_idf_index: Arc<TFIDFIndex>,
     ) -> Result<(), WaCustomError> {
-        tf_idf_index.persist(
-            &collection.meta.name,
-            &self.lmdb_env,
-            self.lmdb_tf_idf_index_db,
-        )?;
+        tf_idf_index.persist(&self.index_data_map, &collection.meta.name)?;
         *collection.tf_idf_index.write() = Some(tf_idf_index);
         Ok(())
     }
@@ -1317,11 +1323,7 @@ impl CollectionsMap {
         collection: &Collection,
         usv_index: Arc<USVIndex>,
     ) -> Result<(), WaCustomError> {
-        usv_index.persist(
-            &collection.meta.name,
-            &self.lmdb_env,
-            self.lmdb_usv_index_db,
-        )?;
+        usv_index.persist(&self.index_data_map, &collection.meta.name)?;
         *collection.usv_index.write() = Some(usv_index);
         Ok(())
     }
@@ -1360,7 +1362,7 @@ impl CollectionsMap {
         match self.inner_collections.get(name) {
             Some(collection) => match collection.hnsw_index.write().take() {
                 Some(hnsw_index) => {
-                    HNSWIndex::delete(&self.lmdb_env, self.lmdb_hnsw_index_db, name)?;
+                    self.index_data_map.remove(name, IndexType::Hnsw)?;
                     Ok(Some(hnsw_index))
                 }
                 None => Ok(None),
@@ -1376,7 +1378,7 @@ impl CollectionsMap {
         match self.inner_collections.get(name) {
             Some(collection) => match collection.inverted_index.write().take() {
                 Some(inverted_index) => {
-                    InvertedIndex::delete(&self.lmdb_env, self.lmdb_inverted_index_db, name)?;
+                    self.index_data_map.remove(name, IndexType::Inverted)?;
                     Ok(Some(inverted_index))
                 }
                 None => Ok(None),
@@ -1392,7 +1394,7 @@ impl CollectionsMap {
         match self.inner_collections.get(name) {
             Some(collection) => match collection.tf_idf_index.write().take() {
                 Some(tf_idf_index) => {
-                    TFIDFIndex::delete(&self.lmdb_env, self.lmdb_tf_idf_index_db, name)?;
+                    self.index_data_map.remove(name, IndexType::TfIdf)?;
                     Ok(Some(tf_idf_index))
                 }
                 None => Ok(None),
@@ -1400,6 +1402,8 @@ impl CollectionsMap {
             None => Ok(None),
         }
     }
+
+    // @TODO: Why not `remove_usv_index`?
 
     /// Removes a collection from the in-memory map, as well as
     /// deletes the collection metadata persisted on the disk


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->

## Explanation
In certain cases, cosdata stores data in lmdb databases. This PR replaces (most of) them with TreeMap which is the internal persistent key-value store implementation based on BufferManager. 

<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fixes #

## Essential Checklist
<!-- Please tick the relevant boxes by putting an "x" in them. -->
- [ ] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR does not contain any unnecessary/auto generated code changes.
- [x] The PR is made from a branch that's **not** called "main" and is up-to-date with "main".
- [x] The PR is **assigned** to the appropriate reviewers 

@a-rustacean @tinkn  Could you please review this when you have a moment? Thank you!
