### PR TITLE
fix(lmdb): make LMDB map size configurable via config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -40,3 +40,7 @@ batch_size = 8  # only required with "batch" indexing mode
 [grpc]
 host = "127.0.0.1" # Optional - if not specified uses default loopback address
 port = 50051       # Optional - if not specified will use default 50051
+
+[lmdb]
+map_size = 1_073_741_824 # 1 GB default
+max_dbs = 10

--- a/src/config_loader.rs
+++ b/src/config_loader.rs
@@ -25,6 +25,7 @@ pub struct Config {
     #[serde(default)]
     pub cache: CacheConfig,
     pub epoch_length: u64,
+    pub lmdb: Option<LmdbConfig>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -204,6 +205,12 @@ pub struct CacheConfig {
     // Probability factor for eviction (0.0-1.0)
     #[serde(default = "default_eviction_probability")]
     pub eviction_probability: f32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LmdbConfig {
+    pub map_size: usize,
+    pub max_dbs: u32,
 }
 
 fn default_max_collections() -> usize {

--- a/src/models/types.rs
+++ b/src/models/types.rs
@@ -1653,10 +1653,23 @@ pub fn get_app_env(
 
     // Ensure the database directory exists
     create_dir_all(&db_path).map_err(|e| WaCustomError::DatabaseError(e.to_string()))?;
+
+    let lmdb_cfg = config.lmdb.as_ref();
+
+    let lmdb_map_size = lmdb_cfg.map(|c| c.map_size).unwrap_or(1_073_741_824); // default: 1GB
+
+    let lmdb_max_dbs = lmdb_cfg.map(|c| c.max_dbs).unwrap_or(10);
+
+    log::info!(
+        "Initializing LMDB: map_size={} bytes, max_dbs={}",
+        lmdb_map_size,
+        lmdb_max_dbs
+    );
+
     // Initialize the environment
     let env = Environment::new()
-        .set_max_dbs(10)
-        .set_map_size(1048576000) // Set the maximum size of the database to 1GB
+        .set_max_dbs(lmdb_max_dbs)
+        .set_map_size(lmdb_map_size)
         .open(&db_path)
         .map_err(|e| WaCustomError::DatabaseError(e.to_string()))?;
 


### PR DESCRIPTION
for issue : https://github.com/cosdata/cosdata/issues/372

- Remove hard-coded 1GB LMDB map size
- Add lmdb.map_size and lmdb.max_dbs config options
- Keep backward-compatible defaults

